### PR TITLE
Add personal images folder support for privacy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ python generate.py                      # All cards
 python generate.py --letters a,d,o      # Specific letters only
 python generate.py --font Lato          # Override font for all cards
 python generate.py --no-placeholders    # Skip placeholder image generation
+python generate.py --personal-dir /path # Custom personal photos location
 ```
 
 ## Architecture
@@ -39,10 +40,42 @@ python generate.py --no-placeholders    # Skip placeholder image generation
 cards.csv              # Word list config (letter, word, image filename, font, personal flag)
 generate.py            # Main PDF generator (reportlab + Pillow)
 draw_placeholders.py   # Generates simple hand-drawn placeholder PNGs
-images/                # All card images (personal photos + generated placeholders)
+images/                # Generic card images (placeholders, clipart)
 fonts/                 # Drop custom .ttf files here, they're auto-registered
 letterkaarten.pdf      # Generated output (gitignored)
 ```
+
+### What goes where
+
+**In the repo (public):**
+- Code: `generate.py`, `draw_placeholders.py`
+- Config: `cards.csv`, `CLAUDE.md`
+- Fonts: `fonts/` folder
+- Generic images: `images/` (placeholders, non-personal illustrations)
+
+**Outside the repo (private):**
+- Personal photos: `~/.lettercards/personal/` (or custom location)
+- Generated PDF: `letterkaarten.pdf` (gitignored)
+
+### Personal images folder
+
+Personal photos (family members, etc.) are stored outside the repo for privacy.
+
+**Default location:** `~/.lettercards/personal/`
+
+**Override via environment variable:**
+```bash
+export LETTERCARDS_PERSONAL_DIR=/custom/path
+```
+
+**Override via CLI flag:**
+```bash
+python generate.py --personal-dir /custom/path
+```
+
+The lookup order is: CLI flag > environment variable > default path.
+
+For cards marked `personal=yes` in `cards.csv`, the generator looks for the image in the personal folder first, then falls back to `images/`.
 
 ### cards.csv format
 
@@ -95,7 +128,7 @@ Each letter has a unique accent color defined in `LETTER_COLORS` in generate.py.
 
 - Jeroen will add words and ideas over time
 - When adding a new word: add CSV row + image, regenerate PDF, verify it looks right
-- For personal photo cards: Jeroen provides the photos, they get cropped/placed in images/
+- For personal photo cards: Jeroen provides the photos, they go in `~/.lettercards/personal/`
 - For generic words: draw_placeholders.py creates simple Pillow-drawn illustrations; these can be upgraded to better images over time
 
 ## Workflow
@@ -110,7 +143,9 @@ Each letter has a unique accent color defined in `LETTER_COLORS` in generate.py.
 2. Create a feature branch: `git checkout -b issue-3-letter-i`
 3. Make changes, test with `python generate.py`
 4. Create PR referencing the issue (e.g., "Fixes #3")
-5. Merge when ready — issue auto-closes
+5. Wait for review/approval, then merge — issue auto-closes
+
+**Important:** Direct pushes to `master` are blocked. All changes must go through a PR with at least one approval.
 
 ### Communication via GitHub
 - Jeroen may comment on issues/PRs from the web

--- a/generate.py
+++ b/generate.py
@@ -13,6 +13,12 @@ Usage:
     python generate.py                      # Generate all cards
     python generate.py --letters a,d,o      # Only specific letters
     python generate.py --font Lato          # Override font for all
+    python generate.py --personal-dir /path # Override personal images location
+
+Personal images location (for photos marked personal=yes in CSV):
+  1. CLI flag: --personal-dir /custom/path
+  2. Environment variable: LETTERCARDS_PERSONAL_DIR=/custom/path
+  3. Default: ~/.lettercards/personal/
 """
 
 import csv
@@ -88,6 +94,17 @@ SYSTEM_FONTS = {
 
 # Default rotation of fonts so each letter gets variety
 DEFAULT_FONTS = ["DejaVuSans", "Lato", "Carlito", "LiberationSans"]
+
+
+# ── Personal Images Directory ──────────────────────────────────────
+
+def get_personal_images_dir(cli_arg=None):
+    """Get personal images directory using layered config: CLI > env > default."""
+    if cli_arg:
+        return Path(cli_arg)
+    if env_dir := os.environ.get('LETTERCARDS_PERSONAL_DIR'):
+        return Path(env_dir)
+    return Path.home() / '.lettercards' / 'personal'
 
 def register_fonts():
     """Register system fonts and any custom fonts in fonts/ folder."""
@@ -336,7 +353,27 @@ def load_cards(csv_path, letters_filter=None):
     return cards
 
 
-def generate_pdf(cards, output_path, images_dir, available_fonts, font_override=None):
+def get_image_path(card, images_dir, personal_dir):
+    """Get the image path for a card, checking personal dir first for personal photos."""
+    if not card['image']:
+        return None
+
+    # For personal photos, check personal dir first
+    if card['personal'] == 'yes':
+        personal_path = personal_dir / card['image']
+        if personal_path.exists():
+            return str(personal_path)
+        # Fall back to images/ if not found in personal dir
+
+    # Check images/ folder
+    images_path = os.path.join(images_dir, card['image'])
+    if os.path.exists(images_path):
+        return images_path
+
+    return None
+
+
+def generate_pdf(cards, output_path, images_dir, personal_dir, available_fonts, font_override=None):
     """Generate the printable PDF with all cards."""
     c = canvas.Canvas(str(output_path), pagesize=A4)
     c.setTitle("Letterkaarten")
@@ -348,7 +385,7 @@ def generate_pdf(cards, output_path, images_dir, available_fonts, font_override=
 
     for card in cards:
         font_name = pick_font(card['word'], card['font'] or font_override, available_fonts)
-        img_path = os.path.join(images_dir, card['image']) if card['image'] else None
+        img_path = get_image_path(card, images_dir, personal_dir)
 
         all_items.append(('picture', card, font_name, img_path))
 
@@ -400,11 +437,14 @@ def main():
                         help='Skip generating placeholder images')
     parser.add_argument('--csv', type=str, default='cards.csv',
                         help='Path to the CSV config file')
+    parser.add_argument('--personal-dir', type=str, default=None,
+                        help='Directory for personal photos (default: ~/.lettercards/personal/)')
     args = parser.parse_args()
 
     base_dir = Path(__file__).parent
     csv_path = base_dir / args.csv
     images_dir = base_dir / "images"
+    personal_dir = get_personal_images_dir(args.personal_dir)
     output_path = base_dir / args.output
 
     # Register fonts
@@ -431,8 +471,9 @@ def main():
         generate_placeholder_images(cards, images_dir)
 
     # Generate PDF
-    print("\nGenerating PDF...")
-    generate_pdf(cards, output_path, images_dir, available_fonts, args.font)
+    print(f"\nPersonal images dir: {personal_dir}")
+    print("Generating PDF...")
+    generate_pdf(cards, output_path, images_dir, personal_dir, available_fonts, args.font)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Personal photos now stored outside repo at `~/.lettercards/personal/` for privacy
- Configurable via env var `LETTERCARDS_PERSONAL_DIR` or `--personal-dir` flag
- Updated CLAUDE.md with architecture guidelines documenting what goes where

## Test plan
- [ ] Create `~/.lettercards/personal/` and add a test image
- [ ] Run `python generate.py` - verify it finds personal images
- [ ] Test env override: `LETTERCARDS_PERSONAL_DIR=/tmp python generate.py`
- [ ] Test CLI override: `python generate.py --personal-dir /tmp`

## Next steps (after merge)
1. Make repo public: `gh repo edit --visibility public`
2. Set up branch protection on master

🤖 Generated with [Claude Code](https://claude.ai/claude-code)