### PR TITLE
Add personal photo processing workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,11 @@ python generate.py --personal-dir /path # Custom personal photos location
 ```
 cards.csv              # Word list config (letter, word, image filename, font, personal flag)
 generate.py            # Main PDF generator (reportlab + Pillow)
+process_photo.py       # Personal photo processor (crop, resize, save)
 draw_placeholders.py   # Generates simple hand-drawn placeholder PNGs
 images/                # Generic card images (placeholders, clipart)
 fonts/                 # Drop custom .ttf files here, they're auto-registered
+requirements.txt       # Python dependencies (pillow, reportlab)
 letterkaarten.pdf      # Generated output (gitignored)
 ```
 
@@ -123,6 +125,60 @@ Each letter has a unique accent color defined in `LETTER_COLORS` in generate.py.
 
 ### Personal photo cards needed
 - abu, oma, opa, mama, papa, Mees, Lena, Laura
+
+## Personal photo workflow
+
+For cards that need real photos (family members, etc.), there's a workflow to help select and process photos.
+
+### Directories
+- **Staging:** `~/.lettercards/staging/` — drop candidate photos here
+- **Personal:** `~/.lettercards/personal/` — processed photos go here (used by generator)
+
+### Quick workflow
+
+```bash
+# 1. See what's in staging
+python process_photo.py --list
+
+# 2. Process a photo (crops to square, resizes to 400x400)
+python process_photo.py oma                    # Uses first image in staging
+python process_photo.py oma IMG_1234.jpg       # Uses specific image
+
+# 3. Preview without saving
+python process_photo.py oma --preview
+
+# 4. Verify by generating the card
+python generate.py --letters o
+```
+
+### With Claude assistance
+
+When working with Claude (CLI, Desktop, or web), you can get help selecting the best photo:
+
+1. Drop multiple candidate photos into `~/.lettercards/staging/`
+2. Tell Claude who they're for (e.g., "photos of oma in staging")
+3. Claude reviews and recommends the best one
+4. Claude processes and saves it
+5. Generate PDF to verify
+
+### Tips
+
+- **Portrait photos work best** — faces should be in the upper portion
+- **Multiple candidates are fine** — Claude can help pick the best one
+- **Photos app limitation:** Can't drag directly from macOS Photos app. Export first (File > Export) or use Share > Save to Files.
+
+### Photos status
+
+| Person | Filename | Status |
+|--------|----------|--------|
+| abu | abu.png | Done |
+| oma | oma.png | Pending |
+| opa | opa.png | Pending |
+| mama | mama.png | Pending |
+| papa | papa.png | Pending |
+| Mees | mees.png | Pending |
+| Lena | lena.png | Pending |
+| Laura | laura.png | Pending |
 
 ## Working style
 

--- a/process_photo.py
+++ b/process_photo.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Personal Photo Processor for Letter Cards
+
+Helps prepare personal photos for use in letter cards. Takes a source image,
+crops it to a square, resizes it, and saves it to the personal photos folder.
+
+Usage:
+    python process_photo.py --list                    # Show staging folder contents
+    python process_photo.py oma                       # Process first image in staging as oma.png
+    python process_photo.py oma photo.jpg             # Process specific file as oma.png
+    python process_photo.py oma photo.jpg --preview   # Show result without saving
+
+The staging folder is: ~/.lettercards/staging/
+The output folder is:  ~/.lettercards/personal/
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from PIL import Image
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+DEFAULT_SIZE = 400  # Output size in pixels (square)
+SUPPORTED_FORMATS = {'.jpg', '.jpeg', '.png', '.heic', '.webp', '.gif', '.bmp'}
+
+
+def get_dirs():
+    """Get staging and personal directories."""
+    base = Path.home() / '.lettercards'
+    staging = base / 'staging'
+    personal = base / 'personal'
+    return staging, personal
+
+
+def ensure_dirs():
+    """Create directories if they don't exist."""
+    staging, personal = get_dirs()
+    staging.mkdir(parents=True, exist_ok=True)
+    personal.mkdir(parents=True, exist_ok=True)
+    return staging, personal
+
+
+def list_staging():
+    """List images in staging folder."""
+    staging, _ = get_dirs()
+
+    if not staging.exists():
+        print(f"Staging folder doesn't exist: {staging}")
+        print(f"Create it with: mkdir -p {staging}")
+        return []
+
+    images = []
+    for f in sorted(staging.iterdir()):
+        if f.suffix.lower() in SUPPORTED_FORMATS:
+            size = f.stat().st_size / 1024  # KB
+            images.append((f.name, size))
+
+    if not images:
+        print(f"No images in staging folder: {staging}")
+        print(f"\nDrop photos there to process them.")
+    else:
+        print(f"Images in {staging}:\n")
+        for name, size in images:
+            print(f"  {name} ({size:.0f} KB)")
+
+    return images
+
+
+def find_source_image(staging, filename=None):
+    """Find source image in staging folder."""
+    if filename:
+        # Specific file requested
+        source = staging / filename
+        if not source.exists():
+            print(f"File not found: {source}")
+            return None
+        return source
+
+    # Find first image in staging
+    for f in sorted(staging.iterdir()):
+        if f.suffix.lower() in SUPPORTED_FORMATS:
+            return f
+
+    print(f"No images found in staging folder: {staging}")
+    return None
+
+
+def process_image(source_path, output_size=DEFAULT_SIZE):
+    """
+    Process an image: crop to square (center) and resize.
+
+    Returns the processed PIL Image.
+    """
+    img = Image.open(source_path)
+
+    # Convert to RGB if necessary (handles RGBA, P mode, etc.)
+    if img.mode in ('RGBA', 'P'):
+        # Create white background for transparency
+        background = Image.new('RGB', img.size, (255, 255, 255))
+        if img.mode == 'P':
+            img = img.convert('RGBA')
+        background.paste(img, mask=img.split()[-1] if img.mode == 'RGBA' else None)
+        img = background
+    elif img.mode != 'RGB':
+        img = img.convert('RGB')
+
+    # Handle EXIF orientation
+    try:
+        from PIL import ExifTags
+        for orientation in ExifTags.TAGS.keys():
+            if ExifTags.TAGS[orientation] == 'Orientation':
+                break
+        exif = img._getexif()
+        if exif:
+            orientation_value = exif.get(orientation)
+            if orientation_value == 3:
+                img = img.rotate(180, expand=True)
+            elif orientation_value == 6:
+                img = img.rotate(270, expand=True)
+            elif orientation_value == 8:
+                img = img.rotate(90, expand=True)
+    except (AttributeError, KeyError, IndexError):
+        pass
+
+    width, height = img.size
+
+    # Crop to square (center crop)
+    # For portraits, take upper portion (likely where face is)
+    # For landscapes, take center
+    min_dim = min(width, height)
+
+    if height > width:
+        # Portrait: take upper portion (face usually in top half)
+        left = 0
+        top = 0
+        right = width
+        bottom = width
+    else:
+        # Landscape or square: center crop
+        left = (width - min_dim) // 2
+        top = (height - min_dim) // 2
+        right = left + min_dim
+        bottom = top + min_dim
+
+    cropped = img.crop((left, top, right, bottom))
+
+    # Resize to output size
+    resized = cropped.resize((output_size, output_size), Image.LANCZOS)
+
+    return resized
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Process personal photos for letter cards",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python process_photo.py --list              # See what's in staging
+  python process_photo.py oma                 # Process first staged image as oma.png
+  python process_photo.py opa IMG_123.jpg     # Process specific file as opa.png
+  python process_photo.py mama --preview      # Preview without saving
+        """
+    )
+    parser.add_argument('name', nargs='?', help='Output name (without extension), e.g., "oma"')
+    parser.add_argument('source', nargs='?', help='Source filename in staging folder (optional)')
+    parser.add_argument('--list', '-l', action='store_true', help='List images in staging folder')
+    parser.add_argument('--preview', '-p', action='store_true', help='Preview only, do not save')
+    parser.add_argument('--size', '-s', type=int, default=DEFAULT_SIZE,
+                        help=f'Output size in pixels (default: {DEFAULT_SIZE})')
+    parser.add_argument('--force', '-f', action='store_true', help='Overwrite existing file')
+
+    args = parser.parse_args()
+
+    # List mode
+    if args.list:
+        list_staging()
+        return
+
+    # Need a name to process
+    if not args.name:
+        parser.print_help()
+        return
+
+    staging, personal = ensure_dirs()
+
+    # Find source image
+    source = find_source_image(staging, args.source)
+    if not source:
+        sys.exit(1)
+
+    # Check output path
+    output_path = personal / f"{args.name}.png"
+    if output_path.exists() and not args.force and not args.preview:
+        print(f"Output file already exists: {output_path}")
+        print(f"Use --force to overwrite, or --preview to see result first")
+        sys.exit(1)
+
+    # Process the image
+    print(f"Processing: {source.name}")
+    print(f"  Source: {source}")
+
+    try:
+        result = process_image(source, args.size)
+    except Exception as e:
+        print(f"Error processing image: {e}")
+        sys.exit(1)
+
+    print(f"  Size: {result.size[0]}x{result.size[1]}")
+
+    if args.preview:
+        print(f"\nPreview mode - not saving.")
+        print(f"Would save to: {output_path}")
+        # Could open preview here, but keeping it simple for now
+        result.show()
+    else:
+        result.save(output_path, 'PNG')
+        print(f"\nSaved: {output_path}")
+        print(f"\nNext steps:")
+        print(f"  1. Verify the image looks good")
+        print(f"  2. Run: python generate.py --letters {args.name[0]}")
+        print(f"  3. Check the PDF")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pillow>=9.0.0
+reportlab>=4.0.0


### PR DESCRIPTION
## Summary
- Add `process_photo.py` script for preparing personal photos (crop, resize, save)
- Add `requirements.txt` with Python dependencies
- Document the full photo workflow in CLAUDE.md

## Usage

```bash
# List photos in staging
python process_photo.py --list

# Process a photo for "oma"
python process_photo.py oma IMG_1234.jpg

# Preview without saving
python process_photo.py oma --preview
```

## Workflow with Claude

1. Drop photos in `~/.lettercards/staging/`
2. Claude reviews and picks the best one
3. Claude processes and saves to `~/.lettercards/personal/`
4. Generate PDF to verify

## Future enhancements (tracked in issues)
- #8: Face detection for auto-centering
- #9: Photos app export workaround
- #7: Full venv setup

Relates to #10

## Test plan
- [x] `process_photo.py --list` shows staging contents
- [x] `process_photo.py name file.jpg` crops and saves
- [x] `--preview` mode works
- [x] Generated cards use the processed photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)