### PR TITLE
Replace lookalike sans-serifs with visually distinct fonts

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -84,16 +84,26 @@ LETTER_COLORS = {
 
 FONT_DIR = Path(__file__).parent / "fonts"
 SYSTEM_FONTS = {
+    # macOS — visually distinct, child-friendly
+    "ArialRounded": "/System/Library/Fonts/Supplemental/Arial Rounded Bold.ttf",
+    "ComicSans":    "/System/Library/Fonts/Supplemental/Comic Sans MS Bold.ttf",
+    "GeorgiaBold":  "/System/Library/Fonts/Supplemental/Georgia Bold.ttf",
+    "BradleyHand":  "/System/Library/Fonts/Supplemental/Bradley Hand Bold.ttf",
+    # Linux fallbacks
     "DejaVuSans":     "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
     "Lato":           "/usr/share/fonts/truetype/lato/Lato-Bold.ttf",
-    "Carlito":        "/usr/share/fonts/truetype/crosextra/Carlito-Bold.ttf",
-    "LiberationSans": "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
     "DejaVuSerif":    "/usr/share/fonts/truetype/dejavu/DejaVuSerif-Bold.ttf",
     "Caladea":        "/usr/share/fonts/truetype/crosextra/Caladea-Bold.ttf",
 }
 
-# Default rotation of fonts so each letter gets variety
-DEFAULT_FONTS = ["DejaVuSans", "Lato", "Carlito", "LiberationSans"]
+# Default rotation — ordered by visual distinctiveness.
+# pick_font() filters to only registered fonts, so missing paths are skipped gracefully.
+# macOS: rounded sans / playful / serif / handwritten — four clearly different styles
+# Linux: sans / sans / serif / serif — better variety than four identical sans-serifs
+DEFAULT_FONTS = [
+    "ArialRounded", "ComicSans", "GeorgiaBold", "BradleyHand",  # macOS
+    "DejaVuSerif", "Caladea", "DejaVuSans", "Lato",             # Linux
+]
 
 
 # ── Personal Images Directory ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #35. Replaces the four near-identical sans-serifs with fonts that look clearly different on printed cards, so Lena actually sees letters in multiple visual forms.

## Problem

`DEFAULT_FONTS` was `[DejaVuSans, Lato, Carlito, LiberationSans]` — all generic sans-serifs. Carlito is metric-compatible with Calibri, LiberationSans with Arial. On print you cannot tell them apart.

## Solution

Four visually distinct styles on macOS:

| Font | Style | Why |
|------|-------|-----|
| ArialRounded | Rounded sans-serif | Clean, child-friendly, single-story 'a' |
| ComicSans | Playful | Double-story 'a', designed for early readers |
| GeorgiaBold | Serif | Strong contrast with sans-serifs |
| BradleyHand | Handwritten | Shows letters can look informal too |

Linux fallbacks retained (`DejaVuSerif`, `Caladea`, `DejaVuSans`, `Lato`) — `pick_font()` silently skips unregistered fonts so this is cross-platform safe.

## How to verify

```bash
python3 generate.py --letters a,e,o,d,m
# Open letterkaarten.pdf — word cards should show clearly different font styles
# "appel", "eend", "oma", "deur", "mama" should each look visually distinct
```

Output on this machine:
```
Available fonts: ArialRounded, ComicSans, GeorgiaBold, BradleyHand
✓ Generated letterkaarten.pdf — 20 cards (15 picture + 5 letter)
```

## Result

The "a" on one card now looks clearly different from the "a" on another — which is the whole pedagogical point of font variety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)