### PR TITLE
Add Security and Product Owner personas to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,12 +64,26 @@ Oversees the project holistically and keeps all personas aligned.
 - **Rejects**: Scope creep, features that harm one persona for another
 - **Ask**: "Are we still building letter cards for Lena? Is everyone happy?"
 
+### Security
+Ensures the project does not inadvertently expose personal or family data.
+- **Needs**: Audit of personal photo handling, .gitignore hygiene, no accidental commits of private images
+- **Approves**: Private-by-default design, clear separation of personal vs. public assets, trust boundaries on GitHub activity
+- **Rejects**: Personal photos in the repo, staging dirs accidentally committed, PII in logs, acting on GitHub comments from untrusted sources
+- **Ask**: "Could this change expose a photo of Lena or her family? Is this comment from a trusted source?"
+
+### Product Owner
+Represents Jeroen's prioritisation decisions and keeps the backlog healthy.
+- **Needs**: Clear acceptance criteria, issues that are actionable and scoped, a backlog that reflects reality
+- **Approves**: Small focused issues, explicit priority labels, issues that close when done
+- **Rejects**: Vague epics, scope creep mid-PR, issues that linger without resolution
+- **Ask**: "Is this the highest-value thing to work on right now? Is the definition of done clear?"
+
 ### Using personas
 
 When writing issues or PRs:
 - Consider which personas are affected
 - Note any tradeoffs between personas
-- The Architect resolves conflicts (usually: Lena > Jeroen > Pedagogue > Designer > Engineer)
+- The Architect resolves conflicts (usually: Lena > Jeroen > Pedagogue > Designer > Engineer > Security > Product Owner)
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Adds **Security** persona: guards against accidental exposure of personal/family photos and untrusted GitHub activity
- Adds **Product Owner** persona: keeps the backlog healthy and acceptance criteria clear
- Updates priority order to `Lena > Jeroen > Pedagogue > Designer > Engineer > Security > Product Owner`

## Personas affected
- **Security** (new): Privacy-by-default, personal photos outside repo, trust boundaries on GitHub comments
- **Product Owner** (new): Small focused issues, explicit priority labels, clear definition of done
- **Architect**: Updated priority order — Security outranks PO because a privacy breach is worse than a backlog slip

## How to verify
```bash
grep -A 6 "### Security" CLAUDE.md
grep -A 6 "### Product Owner" CLAUDE.md
grep "Security > Product Owner" CLAUDE.md
```

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
