### PR TITLE
Require Claude signature on all GitHub comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,13 @@ python generate.py --letters a,o
 \`\`\`
 ```
 
+### GitHub comments and PRs
+All GitHub comments, PR descriptions, and issue bodies written by Claude **must be signed**. Since `gh` posts as Jeroen's account, the signature makes authorship clear:
+
+- PR/issue bodies: end with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+- PR comments (`gh pr comment`): end with `— 🤖 Claude`
+- Issue comments (`gh issue comment`): end with `— 🤖 Claude`
+
 ### Shell command conventions
 - **No compound commands** — never chain with `&&` or `;`; use separate Bash calls instead (permission matching breaks on compound commands)
 - **`gh pr create` / `gh issue create` body** — write body to `.tmp/pr-body.md`, use `--body-file .tmp/pr-body.md`; never inline `--body` with `#` or newlines (breaks permission matching), never heredocs


### PR DESCRIPTION
## Summary
Adds a mandatory signing rule for all Claude-authored GitHub content.

## Problem
`gh pr comment` and `gh issue comment` post as Jeroen's GitHub account. Without a signature, it appears Jeroen wrote comments that Claude actually wrote. This is not allowed.

## Solution
Documents required signatures in CLAUDE.md:
- PR/issue **bodies**: `🤖 Generated with [Claude Code](https://claude.com/claude-code)` (already in use)
- PR/issue **comments**: `— 🤖 Claude` (new requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
