### PR TITLE
Harden settings hooks: loud jq failure and jq-based bypass detection

### DIFF
--- a/.claude/hooks/check-settings-change.sh
+++ b/.claude/hooks/check-settings-change.sh
@@ -2,9 +2,15 @@
 # Hook: PostToolUse on Write|Edit
 # Fires when a Claude settings file is modified.
 # Outputs a systemMessage prompting Security persona review.
+#
+# NOTE: Claude Code runs hooks from the project root, so the relative
+# path in settings.json (bash .claude/hooks/...) is intentional and safe.
 
-# Skip if jq not installed
-command -v jq >/dev/null 2>&1 || exit 0
+# Warn loudly if jq is not installed — do not silently pass
+if ! command -v jq >/dev/null 2>&1; then
+  printf '{"systemMessage":"⚠️ jq is not installed — settings file protection is disabled. Install jq (brew install jq) to enable security checks."}'
+  exit 0
+fi
 
 # Read stdin once into a variable
 input=$(cat)

--- a/.claude/hooks/check-settings-prewrite.sh
+++ b/.claude/hooks/check-settings-prewrite.sh
@@ -3,8 +3,15 @@
 # Runs BEFORE a settings file is written.
 # - Blocks if bypassPermissions is detected (hard stop)
 # - Warns and requires Security review for all other settings changes
+#
+# NOTE: Claude Code runs hooks from the project root, so the relative
+# path in settings.json (bash .claude/hooks/...) is intentional and safe.
 
-command -v jq >/dev/null 2>&1 || exit 0
+# Warn loudly if jq is not installed — do not silently pass
+if ! command -v jq >/dev/null 2>&1; then
+  printf '{"systemMessage":"⚠️ jq is not installed — settings file protection is disabled. Install jq (brew install jq) to enable security checks."}'
+  exit 0
+fi
 
 # Read stdin once into a variable
 input=$(cat)
@@ -16,8 +23,9 @@ echo "$f" | grep -qE '\.claude/.*settings.*\.json' || exit 0
 # Extract content being written (Write uses .content, Edit uses .new_string)
 content=$(echo "$input" | jq -r '.tool_input.content // .tool_input.new_string // empty')
 
-# Hard block: bypassPermissions is never allowed
-if echo "$content" | grep -q 'bypassPermissions'; then
+# Hard block: bypassPermissions is never allowed.
+# Use jq to parse the JSON structurally — handles unicode escapes that fool grep.
+if echo "$content" | jq -e '.. | strings | contains("bypassPermissions")' 2>/dev/null | grep -q 'true'; then
   printf '{"continue": false, "stopReason": "⛔ Blocked: bypassPermissions detected. This grants unlimited tool access with no safety checks. Apply Security persona review — justify explicitly or remove."}'
   exit 0
 fi


### PR DESCRIPTION
## Summary

Hardens the two settings protection hooks from PR #65 with three fixes identified in the security review but deferred to a follow-up issue (#68).

## Changes

**1. Loud jq failure** — both hooks previously used `|| exit 0` when jq was missing, silently disabling all protection. Now outputs a visible `systemMessage` warning so the gap is noticed.

**2. jq-based bypassPermissions detection** — replaced `grep -q 'bypassPermissions'` with `jq -e '.. | strings | contains("bypassPermissions")'`. jq parses JSON structurally and decodes unicode escapes, so a crafted payload like `\u0062ypassPermissions` no longer bypasses the check.

**3. Path documentation** — added a comment explaining the relative hook paths are intentional (Claude Code runs hooks from project root). No path change needed.

## How to Verify

```bash
# Hard block still works
echo '{"tool_name":"Write","tool_input":{"file_path":".claude/settings.local.json","content":"{\"permissions\":{\"defaultMode\":\"bypassPermissions\"}}"}}' | bash .claude/hooks/check-settings-prewrite.sh
# Expected: {"continue": false, "stopReason": "⛔ Blocked..."}

# Unicode escape bypass is now caught
echo '{"tool_name":"Write","tool_input":{"file_path":".claude/settings.local.json","content":"{\"permissions\":{\"defaultMode\":\"\\u0062ypassPermissions\"}}"}}' | bash .claude/hooks/check-settings-prewrite.sh
# Expected: {"continue": false, "stopReason": "⛔ Blocked..."}

# Advisory still fires for normal changes
echo '{"tool_name":"Write","tool_input":{"file_path":".claude/settings.local.json","content":"{\"permissions\":{\"allow\":[\"Bash(git status:*)\"]}}"}}' | bash .claude/hooks/check-settings-prewrite.sh
# Expected: {"systemMessage":"⚠️ Security review required..."}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
