### PR TITLE
Fix pictogram prompt: add no-text instruction

### DIFF
--- a/pictogram_workflow.py
+++ b/pictogram_workflow.py
@@ -52,7 +52,7 @@ SOURCES_MD = Path(__file__).parent / 'images' / 'SOURCES.md'
 # - Dikkie Dik: warm, friendly, slightly more detail
 # - Bobbie: colorful, appealing to toddlers
 # This prompt produces consistent, high-quality results in ChatGPT/DALL-E
-STYLE_PROMPT = """cute, simple, child-friendly illustration style similar to Dutch children's books like Nijntje (Miffy) or Dikkie Dik. Soft rounded shapes, warm colors, gentle outlines, pure white (#FFFFFF) background. The style should be appealing to toddlers (age 2)."""
+STYLE_PROMPT = """cute, simple, child-friendly illustration style similar to Dutch children's books like Nijntje (Miffy) or Dikkie Dik. Soft rounded shapes, warm colors, gentle outlines, pure white (#FFFFFF) background. The style should be appealing to toddlers (age 2). No text, labels, or captions in the image."""
 
 # Grid layouts for ChatGPT image generation
 # We use grids to maximize efficiency with ChatGPT's free tier rate limits.


### PR DESCRIPTION
## Summary

Adds "No text, labels, or captions in the image." to the `STYLE_PROMPT` in `pictogram_workflow.py`.

## Problem

Part of #40. When regenerating `oog` via ChatGPT, the generated image included the word "oog" as a text label overlaid on the illustration. The style prompt had no instruction to suppress text.

This affects all generated images — any word could end up with a label on it.

## Fix

One-line addition to `STYLE_PROMPT`:

```
No text, labels, or captions in the image.
```

This applies to every prompt generated by `pictogram_workflow.py prompt`.

## How to Verify

```bash
venv/bin/python pictogram_workflow.py prompt oog
# Confirm "No text, labels, or captions in the image." appears in the output
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
