### PR TITLE
Add no-cd and no-cat rules to shell command conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,16 @@ old one. Update the old one's status. Never edit the body of an accepted ADR.
 6. Create PR referencing the issue (e.g., "Fixes #3")
 7. Wait for review/approval, then merge — issue auto-closes
 
+### PR scope discipline
+
+Before making any change, orient yourself: run `gh pr list` and check `git branch`. Then decide:
+
+- **Same scope as the open PR?** Add the commit to the current branch and update the PR description to reflect all changes.
+- **Different topic?** Switch to master, create a new branch, open a new PR (and issue if non-trivial).
+- **Unsure?** Ask Jeroen — pausing is always better than silently bloating a PR.
+
+Never let commits accumulate on a branch without a matching PR description. Never use an open PR as a catch-all for unrelated changes.
+
 ### Automated tests
 
 ```bash


### PR DESCRIPTION
## Summary

Adds explicit Claude workflow rules to `CLAUDE.md` to prevent recurring friction during sessions.

## Changes

### Shell command conventions
- **No `cd` prefixes** — `cd /path && git push` doesn't match `Bash(git push:*)` in the allowlist, causing unnecessary approval prompts. Always run commands without a `cd` prefix; the working directory is already the repo root.
- **No `cat` for writing files** — use the Write tool instead of `cat > file` or heredocs
- **Clean up `.tmp/` files** — delete temp files immediately after the `gh`/`git` command that used them

### Workflow
- **Always branch from master** — before creating any branch, `git checkout master` + `git pull` first; never branch from another feature branch
- **PR scope discipline** — before any change, check `gh pr list` and orient to the current branch; same scope → add to existing PR and update description; different topic → new branch/PR; unsure → ask

## Why

These rules were repeatedly violated despite being in memory. Putting them in the always-loaded `CLAUDE.md` makes them harder to miss. Memory is machine-local; `CLAUDE.md` is the versioned source of truth.

## How to Verify

Check `CLAUDE.md`:
- `### Shell command conventions` — three bullet points covering cd, cat, and cleanup
- `### Making changes` — step 2 now says "switch to master and pull first"
- `### PR scope discipline` — new section after Making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
