### PR TITLE
Security hook fixes: jq warn (#82), abs-path cp/mv (#84), bypassPermissions loud warning (#85) + session-start tests (#83)

### DIFF
--- a/.claude/hooks/check-bash-settings-write.sh
+++ b/.claude/hooks/check-bash-settings-write.sh
@@ -8,8 +8,9 @@
 #   cat ... >> .claude/settings.json           (append redirect)
 #   tee .claude/settings.local.json            (tee)
 #   sed -i ... .claude/settings.local.json     (in-place edit)
-#   cp src.json .claude/settings.local.json    (copy to target)
-#   mv /tmp/x.json .claude/settings.json       (move to target)
+#   cp src.json .claude/settings.local.json          (copy to relative target)
+#   cp /tmp/x.json /abs/path/.claude/settings.json   (copy to absolute target, #84)
+#   mv /tmp/x.json .claude/settings.json             (move to target)
 #
 # Does NOT match commands that merely mention a settings path in a string
 # (e.g. git commit messages, grep searches, cat reads).
@@ -25,7 +26,7 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Only match when a settings file is the TARGET of a write operation.
 # Patterns: redirect (>/>>), tee, sed -i, cp/mv with settings as destination.
-if ! echo "$cmd" | grep -qE '(>>?\s*["\x27]?\.claude/[^"'"'"' ]*settings[^"'"'"' ]*\.json|tee\s+["\x27]?\.claude/[^"'"'"' ]*settings[^"'"'"' ]*\.json|sed\s+-i\s+.*\.claude/.*settings.*\.json|(cp|mv)\b.*\s+["\x27]?\.claude/[^"'"'"' ]*settings[^"'"'"' ]*\.json)'; then
+if ! echo "$cmd" | grep -qE '(>>?\s*["\x27]?\.claude/[^"'"'"' ]*settings[^"'"'"' ]*\.json|tee\s+["\x27]?\.claude/[^"'"'"' ]*settings[^"'"'"' ]*\.json|sed\s+-i\s+.*\.claude/.*settings.*\.json|(cp|mv)\b.*\s+["\x27]?[^ ]*\.claude/[^"'"'"' ]*settings[^"'"'"' ]*\.json)'; then
   exit 0
 fi
 

--- a/.claude/hooks/check-settings-change.sh
+++ b/.claude/hooks/check-settings-change.sh
@@ -21,4 +21,11 @@ f=$(echo "$input" | jq -r '.tool_input.file_path // empty')
 # Only trigger on .claude/*settings*.json files
 echo "$f" | grep -qE '\.claude/.*settings.*\.json' || exit 0
 
+# Louder warning if bypassPermissions was written (#85)
+content=$(echo "$input" | jq -r '.tool_input.content // .tool_input.new_string // empty' 2>/dev/null)
+if echo "$content" | grep -qi 'bypasspermissions'; then
+  printf '{"systemMessage":"⛔ WARNING: bypassPermissions was just written to a settings file. This grants unlimited tool access with no safety checks. Review immediately — revert if this was not intentional."}'
+  exit 0
+fi
+
 printf '{"systemMessage":"⚠️ Security review required: a settings file was modified. Apply the Security persona before continuing — check for overly broad permissions, bypassPermissions usage, or commands that could expose personal data or grant excessive access."}'

--- a/.claude/hooks/session-start-github-check.sh
+++ b/.claude/hooks/session-start-github-check.sh
@@ -4,13 +4,28 @@
 # anything updated in the last 7 days as a session context message.
 
 command -v gh >/dev/null 2>&1 || exit 0
-command -v jq >/dev/null 2>&1 || exit 0
+
+# Warn loudly if jq is missing rather than silently skipping (#82)
+if ! command -v jq >/dev/null 2>&1; then
+  printf '{"systemMessage":"⚠️ jq is not installed — session-start security checks disabled. External GitHub comments will NOT be flagged as untrusted. Install jq to restore this guard: brew install jq"}'
+  exit 0
+fi
 
 # Fetch open PRs
-prs=$(gh pr list --state open --json number,title,updatedAt 2>/dev/null)
+# LETTERCARDS_TEST_PR_JSON: inject pre-formed JSON in tests instead of calling gh (#83)
+if [ -n "$LETTERCARDS_TEST_PR_JSON" ]; then
+  prs="$LETTERCARDS_TEST_PR_JSON"
+else
+  prs=$(gh pr list --state open --json number,title,updatedAt 2>/dev/null)
+fi
 
 # Fetch open issues updated in last 7 days (limit 20 for speed)
-issues=$(gh issue list --state open --json number,title,updatedAt,comments --limit 20 2>/dev/null)
+# LETTERCARDS_TEST_ISSUES_JSON: inject pre-formed JSON in tests instead of calling gh (#83)
+if [ -n "$LETTERCARDS_TEST_ISSUES_JSON" ]; then
+  issues="$LETTERCARDS_TEST_ISSUES_JSON"
+else
+  issues=$(gh issue list --state open --json number,title,updatedAt,comments --limit 20 2>/dev/null)
+fi
 
 # Build summary of open PRs
 pr_summary=$(echo "$prs" | jq -r '.[] | "  PR #\(.number): \(.title)"' 2>/dev/null)

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -88,9 +88,16 @@ H2="$HOOKS_DIR/check-settings-change.sh"
 
 out=$(write_payload ".claude/settings.local.json" '{}' | bash "$H2")
 assert_contains     "Advisory: Write to settings.local.json" 'systemMessage' "$out"
+assert_not_contains "Advisory must not show hard-block marker" '"continue": false' "$out"
 
 out=$(write_payload ".claude/settings.json" '{}' | bash "$H2")
 assert_contains     "Advisory: Write to settings.json" 'systemMessage' "$out"
+
+out=$(write_payload ".claude/settings.local.json" '{"permissions":{"defaultMode":"bypassPermissions"}}' | bash "$H2")
+assert_contains     "Loud warning: bypassPermissions written to settings file" 'bypassPermissions was just written' "$out"
+
+out=$(edit_payload ".claude/settings.local.json" '"bypassPermissions": true' | bash "$H2")
+assert_contains     "Loud warning: bypassPermissions in Edit new_string" 'bypassPermissions was just written' "$out"
 
 out=$(write_payload "generate.py" 'code' | bash "$H2")
 assert_silent       "Silent: Write to non-settings file" "$out"
@@ -126,10 +133,16 @@ out=$(bash_payload "sed -i 's/x/y/' .claude/settings.local.json" | bash "$H3")
 assert_contains     "Advisory: sed -i on settings.local.json" 'systemMessage' "$out"
 
 out=$(bash_payload 'cp /tmp/x.json .claude/settings.local.json' | bash "$H3")
-assert_contains     "Advisory: cp to settings.local.json" 'systemMessage' "$out"
+assert_contains     "Advisory: cp to relative settings.local.json" 'systemMessage' "$out"
 
 out=$(bash_payload 'mv /tmp/x.json .claude/settings.json' | bash "$H3")
-assert_contains     "Advisory: mv to settings.json" 'systemMessage' "$out"
+assert_contains     "Advisory: mv to relative settings.json" 'systemMessage' "$out"
+
+out=$(bash_payload 'cp /tmp/x.json /Users/jeroen/lettercards/.claude/settings.local.json' | bash "$H3")
+assert_contains     "Advisory: cp to absolute-path settings.local.json (#84)" 'systemMessage' "$out"
+
+out=$(bash_payload 'mv /tmp/x.json /abs/path/.claude/settings.json' | bash "$H3")
+assert_contains     "Advisory: mv to absolute-path settings.json (#84)" 'systemMessage' "$out"
 
 out=$(bash_payload 'cat .claude/settings.json' | bash "$H3")
 assert_silent       "Silent: cat (read only)" "$out"
@@ -151,14 +164,60 @@ assert_silent       "Silent: payload with no command field" "$out"
 
 # ────────────────────────────────────────────────────────────────────────────
 echo ""
+echo "=== session-start-github-check.sh (SessionStart) ==="
+H4="$HOOKS_DIR/session-start-github-check.sh"
+
+OWNER_ISSUES=$(jq -n '[{
+  "number": 1, "title": "Test issue",
+  "comments": [{"author": {"login": "jvspl"}, "body": "Owner comment here"}]
+}]')
+
+EXTERNAL_ISSUES=$(jq -n '[{
+  "number": 2, "title": "Another issue",
+  "comments": [{"author": {"login": "badactor"}, "body": "External comment here"}]
+}]')
+
+MIXED_ISSUES=$(jq -n '[{
+  "number": 3, "title": "Mixed issue",
+  "comments": [
+    {"author": {"login": "jvspl"}, "body": "Trusted comment"},
+    {"author": {"login": "attacker"}, "body": "Untrusted comment"}
+  ]
+}]')
+
+out=$(LETTERCARDS_TEST_ISSUES_JSON="$OWNER_ISSUES" LETTERCARDS_TEST_PR_JSON='[]' bash "$H4")
+assert_contains     "Session-start: owner comment shown without warning" '💬 @jvspl' "$out"
+assert_not_contains "Session-start: owner comment not flagged as external" '⚠️ external comment' "$out"
+
+out=$(LETTERCARDS_TEST_ISSUES_JSON="$EXTERNAL_ISSUES" LETTERCARDS_TEST_PR_JSON='[]' bash "$H4")
+assert_contains     "Session-start: external comment flagged with warning" '⚠️ external comment from @badactor' "$out"
+assert_not_contains "Session-start: external comment not shown as owner" '💬 @badactor' "$out"
+
+out=$(LETTERCARDS_TEST_ISSUES_JSON="$MIXED_ISSUES" LETTERCARDS_TEST_PR_JSON='[]' bash "$H4")
+assert_contains     "Session-start: trusted comment shown in mixed issue" '💬 @jvspl' "$out"
+assert_contains     "Session-start: untrusted comment flagged in mixed issue" '⚠️ external comment from @attacker' "$out"
+
+out=$(LETTERCARDS_TEST_ISSUES_JSON='[]' LETTERCARDS_TEST_PR_JSON='[]' bash "$H4")
+assert_contains     "Session-start: no-comment state produces header" 'Session start' "$out"
+assert_not_contains "Session-start: no spurious warnings on empty issues" '⚠️ external comment' "$out"
+
+# ────────────────────────────────────────────────────────────────────────────
+echo ""
 echo "=== jq-missing: fail-closed behaviour ==="
-# session-start-github-check.sh is excluded: it calls gh live and cannot be pipe-tested.
 
 out=$(write_payload ".claude/settings.local.json" '{}' | env PATH=/nonexistent /bin/bash "$H1")
 assert_contains "H1 (prewrite): hard-blocks when jq is missing" '"continue": false' "$out"
 
 out=$(bash_payload 'echo {} > .claude/settings.local.json' | env PATH=/nonexistent /bin/bash "$H3")
 assert_contains "H3 (bash-write): hard-blocks when jq is missing" '"continue": false' "$out"
+
+# H4 jq-missing: hook checks gh first, so we need a mock gh in PATH but no jq
+MOCK_BIN=$(mktemp -d)
+printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/gh"
+chmod +x "$MOCK_BIN/gh"
+out=$(LETTERCARDS_TEST_ISSUES_JSON='[]' LETTERCARDS_TEST_PR_JSON='[]' env PATH="$MOCK_BIN" /bin/bash "$H4")
+rm -rf "$MOCK_BIN"
+assert_contains "H4 (session-start): warns when jq is missing (#82)" '⚠️ jq is not installed' "$out"
 
 # ────────────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Four security hook fixes shipped together — all small, all tested.

- **#82**: session-start hook warned silently (exit 0) when jq missing — now emits a visible `⚠️` message
- **#84**: cp/mv pattern in Bash hook only matched relative-path destinations — now matches absolute paths too
- **#85**: PostToolUse hook gave the same generic advisory for all settings writes — now emits a distinct `⛔ WARNING` when `bypassPermissions` was actually written
- **#83**: session-start hook had no pipe-test coverage — added 8 new test cases using `LETTERCARDS_TEST_ISSUES_JSON` / `LETTERCARDS_TEST_PR_JSON` env vars

## Problem

These four gaps were identified during the security hook architecture review:

- A session on a machine without `jq` would show no `⚠️ external comment` labels with no indication the guard was inactive (#82)
- `cp /abs/path/.claude/settings.json` bypassed the Bash hook's cp/mv guard (#84)
- A low-attention session could acknowledge the generic PostToolUse advisory after writing `bypassPermissions` without noticing what was written (#85)
- The session-start comment-labeling logic (added for #76) was untested (#83)

## Solution

- **session-start hook**: replaced silent `|| exit 0` jq check with an explicit warning message; added env-var overrides for test injection
- **Bash hook**: changed `["\x27]?\.claude/` to `["\x27]?[^ ]*\.claude/` in the cp/mv branch, allowing any leading path prefix
- **PostToolUse hook**: extract written content and grep for `bypassPermissions` before the generic advisory
- **test_hooks.sh**: new `session-start-github-check.sh` section (owner comment, external comment, mixed, empty, jq-missing); new PostToolUse bypassPermissions tests; new absolute-path cp/mv tests

## How to Verify

```bash
bash tests/test_hooks.sh
# Expected: 43 passed, 0 failed
```

Manual smoke-test for #82 — uninstall jq temporarily or rename the binary; restart a Claude Code session; confirm the warning appears in session context.

Manual smoke-test for #85 — write `{"permissions":{"defaultMode":"bypassPermissions"}}` to `.claude/settings.local.json` via the Write tool; confirm the `⛔ WARNING` message fires instead of the generic advisory.

## Result

43 pipe-tests passing. All four hooks now have test coverage. The session-start hook now fails visibly rather than silently when degraded.

Closes #82, #83, #84, #85. Also unblocks closing #76 (pipe-test coverage now landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
