### PR TITLE
Add Tata to cards.csv (#34)

### DIFF
--- a/cards.csv
+++ b/cards.csv
@@ -44,5 +44,6 @@ l,Laura,laura.png,,yes
 r,regen,regen.png,,no
 t,tand,tand.png,,no
 t,tafel,tafel.png,,no
+t,Tata,tata.png,,yes
 v,vis,vis.png,,no
 v,vlinder,vlinder.png,,no


### PR DESCRIPTION
## Summary

Adds the CSV entry for Tata (T) to `cards.csv`. This is the code half of #34 — the photo is still needed separately.

## Problem

`cards.csv` had no entry for Tata, so the card was never generated even once a photo exists.

## Solution

Added `t,Tata,tata.png,,yes` after the existing T entries (`tand`, `tafel`).

## How to Verify

```bash
# Once tata.png is in ~/.lettercards/personal/:
python generate.py --letters t
# Open PDF — should show Tata card alongside tand and tafel
```

Until the photo lands, the generator will skip the Tata card (personal=yes, no placeholder generated).

## Still needed

- [ ] Photo for Tata → `~/.lettercards/personal/tata.png`
  - Drop candidate photo(s) in `~/.lettercards/staging/`
  - Run: `python process_photo.py tata`

Partially closes #34 (CSV done; photo pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
