### PR TITLE
MCP photo wizard: picker-based flow with AI pre-selection (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 .DS_Store
 venv/
+venv-mcp/
 letterkaarten.pdf
 deck-state.json
 .tmp/

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,13 +1,16 @@
 # MCP Photo Wizard — Setup Guide
 
-This lets you select and process personal photos for letter cards entirely inside
-Claude Desktop. See real card previews, pick the best one, and it gets saved to your
-personal library — no command line needed.
+This lets you select and process personal photos for letter cards inside any
+MCP-capable AI client. A native file picker opens so you can choose photos from
+anywhere on your computer, the AI evaluates the best candidates, and you see them
+rendered as actual lettercards before saving — no command line needed for the
+selection step.
 
 ## Requirements
 
-- Claude Desktop installed and signed in
-- Python 3.10+ (macOS: `brew install python@3.13` if needed)
+- An MCP-capable AI client (Claude Desktop, ChatGPT Desktop, or any client that
+  supports the MCP protocol)
+- Python 3.10+
 - The lettercards repo cloned locally
 
 ## One-time setup
@@ -17,14 +20,30 @@ personal library — no command line needed.
 From the repo root:
 
 ```bash
-python3.13 -m venv venv-mcp
+python3 -m venv venv-mcp
 venv-mcp/bin/pip install "mcp[cli]" pillow
 ```
 
-### 2. Register the server with Claude Desktop
+On Windows:
+```
+python -m venv venv-mcp
+venv-mcp\Scripts\pip install "mcp[cli]" pillow
+```
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
-(create it if it doesn't exist):
+### 2. Register the server with your AI client
+
+The config location depends on your client and OS:
+
+**Claude Desktop — macOS:**
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+
+**Claude Desktop — Windows:**
+`%APPDATA%\Claude\claude_desktop_config.json`
+
+**Claude Desktop — Linux:**
+`~/.config/Claude/claude_desktop_config.json`
+
+In all cases, add:
 
 ```json
 {
@@ -37,44 +56,66 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
 }
 ```
 
-Replace `/absolute/path/to/repo` with the actual path to your clone.
-To find it: `pwd` from the repo root.
+On Windows use the full path with backslashes and `venv-mcp\Scripts\python.exe`.
 
-### 3. Restart Claude Desktop
+Replace `/absolute/path/to/repo` with the actual path to your clone
+(`pwd` from the repo root gives you this).
 
-Quit and reopen Claude Desktop. You should see a hammer icon (🔨) in the
-chat input area — that means MCP tools are active.
+### 3. Restart the AI client
+
+Quit and reopen the client. You should see a tools/hammer icon in the chat
+input area — that means MCP tools are active.
 
 ## Using the wizard
 
-### Option A — Staging folder (recommended for batches)
+### Standard flow
 
-1. Copy your candidate photos to `~/.lettercards/staging/`
-2. Open Claude Desktop (or a Cowork session)
-3. Say something like: *"Help me pick a photo for Tata"*
-4. Claude calls `list_staging_photos`, previews all photos, and if there are 4 or more
-   shows a side-by-side comparison of the top 3
-5. Confirm your choice — Claude saves it to `~/.lettercards/personal/`
-6. Back in the terminal: `python generate.py --letters t` to generate the PDF
+1. Open your AI client
+2. Say something like: *"Help me pick a photo for Tata"*
+3. The AI calls `pick_photos("Tata")` — **a native file picker dialog opens**
+4. Select your candidate photos (any folder, any number)
+5. The AI evaluates them:
+   - 1–3 photos: renders them directly as lettercards side-by-side
+   - 4+ photos: shows a numbered thumbnail grid first, picks the best 2–3,
+     then renders those as lettercards
+6. Expand the tool output section in your AI client to see the rendered cards
+7. Tell the AI which one you want: *"use number 2"*
+8. The AI saves it to `~/.lettercards/personal/` and tells you the generate command
 
-### Option B — Drag photos into the chat
+### Headless / no display fallback
 
-1. Open Claude Desktop
-2. Drag photos directly into the chat input
-3. Say something like: *"Help me pick a photo for Tata"*
-4. Claude sees the inline images and generates card previews using them directly
-5. Confirm and save as above
+If the file picker dialog cannot open (e.g. a remote session without a display),
+tell the AI where the photos are:
 
-> **Note:** Card previews appear inside the "Used lettercards integration" section —
-> click that header to expand it and see the cards.
+*"Help me pick a photo for Tata — the photos are in ~/Downloads/family"*
+
+The AI will call `pick_photos("Tata", directory="~/Downloads/family")` to list
+photos from that directory instead.
+
+### Staging folder fallback
+
+If you prefer copying photos to a fixed location first, put them in
+`~/.lettercards/staging/` and ask the AI to use `list_staging_photos` instead
+of the picker.
 
 ## Troubleshooting
 
-**Hammer icon not showing:** Claude Desktop didn't pick up the config.
-Check the JSON is valid (no trailing commas) and restart Claude Desktop.
+**Tools icon not showing:** The client didn't pick up the config.
+Check the JSON is valid (no trailing commas) and restart the client.
 
-**"Server failed to start":** Check the paths in the config are absolute and correct.
-Test manually: `venv-mcp/bin/python mcp_server.py` should start without errors.
+**"Server failed to start":** The paths in the config are wrong or the venv is
+missing. Test manually: `venv-mcp/bin/python mcp_server.py` should exit cleanly
+(no output means success; it waits for stdin).
 
-**Card preview looks wrong:** The crop takes the top square of portrait photos. If the
-face is cut off, try a photo where the face is in the upper portion of the frame.
+**File picker doesn't appear / appears behind other windows:** On macOS, the
+dialog may appear behind the AI client window. Check the taskbar/dock.
+On Linux, `tkinter` requires a display — install `python3-tk` if missing
+(`sudo apt install python3-tk` on Debian/Ubuntu).
+
+**Card preview looks wrong:** The crop takes the top square of portrait photos.
+If the face is cut off, try a photo where the face is in the upper portion of
+the frame, or choose a different candidate from the comparison grid.
+
+**Wrong font / plain text on cards:** The server looks for fonts in the repo's
+`fonts/` directory first, then common system locations. To guarantee a specific
+font, drop a `.ttf` file into `fonts/` — it will be picked up automatically.

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,0 +1,66 @@
+# MCP Photo Wizard — Setup Guide
+
+This lets you select and process personal photos for letter cards entirely inside
+Claude Desktop. Drop photos into the conversation, see real card previews, pick one,
+and it gets saved to your personal library — no command line needed.
+
+## Requirements
+
+- Claude Desktop installed and signed in
+- Python 3.10+ (macOS: `brew install python@3.13` if needed)
+- The lettercards repo cloned locally
+
+## One-time setup
+
+### 1. Create the MCP virtual environment
+
+From the repo root:
+
+```bash
+python3.13 -m venv venv-mcp
+venv-mcp/bin/pip install "mcp[cli]" pillow
+```
+
+### 2. Register the server with Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
+(create it if it doesn't exist):
+
+```json
+{
+  "mcpServers": {
+    "lettercards": {
+      "command": "/absolute/path/to/repo/venv-mcp/bin/python",
+      "args": ["/absolute/path/to/repo/mcp_server.py"]
+    }
+  }
+}
+```
+
+Replace `/absolute/path/to/repo` with the actual path to your clone.
+To find it: `pwd` from the repo root.
+
+### 3. Restart Claude Desktop
+
+Quit and reopen Claude Desktop. You should see a hammer icon (🔨) in the
+chat input area — that means MCP tools are active.
+
+## Using the wizard
+
+1. Open Claude Desktop
+2. Drag one or more photos of the person directly into the chat
+3. Say something like: *"Help me pick a photo for Tata"*
+4. Claude will generate a card preview for each photo and recommend the best one
+5. Confirm your choice — Claude saves it to `~/.lettercards/personal/`
+6. Back in the terminal: `python generate.py --letters t` to generate the PDF
+
+## Troubleshooting
+
+**Hammer icon not showing:** Claude Desktop didn't pick up the config.
+Check the JSON is valid (no trailing commas) and restart Claude Desktop.
+
+**"Server failed to start":** Check the paths in the config are absolute and correct.
+Test manually: `venv-mcp/bin/python mcp_server.py` should start without errors.
+
+**Card preview looks wrong:** The photo crop always takes the top square of portrait
+photos. If the face is cut off, try a different photo where the face is higher in frame.

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,8 +1,8 @@
 # MCP Photo Wizard — Setup Guide
 
 This lets you select and process personal photos for letter cards entirely inside
-Claude Desktop. Drop photos into the conversation, see real card previews, pick one,
-and it gets saved to your personal library — no command line needed.
+Claude Desktop. See real card previews, pick the best one, and it gets saved to your
+personal library — no command line needed.
 
 ## Requirements
 
@@ -47,12 +47,26 @@ chat input area — that means MCP tools are active.
 
 ## Using the wizard
 
-1. Open Claude Desktop
-2. Drag one or more photos of the person directly into the chat
+### Option A — Staging folder (recommended for batches)
+
+1. Copy your candidate photos to `~/.lettercards/staging/`
+2. Open Claude Desktop (or a Cowork session)
 3. Say something like: *"Help me pick a photo for Tata"*
-4. Claude will generate a card preview for each photo and recommend the best one
+4. Claude calls `list_staging_photos`, previews all photos, and if there are 4 or more
+   shows a side-by-side comparison of the top 3
 5. Confirm your choice — Claude saves it to `~/.lettercards/personal/`
 6. Back in the terminal: `python generate.py --letters t` to generate the PDF
+
+### Option B — Drag photos into the chat
+
+1. Open Claude Desktop
+2. Drag photos directly into the chat input
+3. Say something like: *"Help me pick a photo for Tata"*
+4. Claude sees the inline images and generates card previews using them directly
+5. Confirm and save as above
+
+> **Note:** Card previews appear inside the "Used lettercards integration" section —
+> click that header to expand it and see the cards.
 
 ## Troubleshooting
 
@@ -62,5 +76,5 @@ Check the JSON is valid (no trailing commas) and restart Claude Desktop.
 **"Server failed to start":** Check the paths in the config are absolute and correct.
 Test manually: `venv-mcp/bin/python mcp_server.py` should start without errors.
 
-**Card preview looks wrong:** The photo crop always takes the top square of portrait
-photos. If the face is cut off, try a different photo where the face is higher in frame.
+**Card preview looks wrong:** The crop takes the top square of portrait photos. If the
+face is cut off, try a photo where the face is in the upper portion of the frame.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -74,6 +74,11 @@ If staging is empty, tell the user to copy photos there first.
 
 The cards are for a toddler (Lena, ~2 years old) learning letter-sound associations.
 A good card photo: face clearly visible, person recognisable, clean background preferred.
+
+Note: card preview images appear inside the "Used lettercards integration" section in
+Claude Desktop — not inline in the chat. Always tell the user to click that section header
+to expand it and see the cards. Say something like: "Click 'Used lettercards integration'
+above to see the card previews."
 """)
 
 # ── Image processing ─────────────────────────────────────────────────────────

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -60,16 +60,15 @@ LETTER_COLORS = {
 mcp = FastMCP("lettercards", instructions="""
 You are helping select and process personal photos for Dutch letter learning cards.
 
-## IMPORTANT: these tools need files on disk
+## Two input modes
 
-These tools work with FILE PATHS only. They cannot access photos that are embedded
-inline in the conversation (e.g. images pasted or dragged directly into the chat).
+These tools accept photos in two ways — use whichever applies:
 
-If the user has dragged photos directly into the chat and you do not have file paths
-for them, say: "I can see your photos but I can't process inline images directly.
-Please copy the photos to ~/.lettercards/staging/ and I'll use those — or add the
-folder containing the photos to the Cowork context panel on the right."
-Do NOT call list_staging_photos() in this case — it won't help.
+**Inline images (dropped into the chat):** Use the `image_data` parameter — pass the
+base64 of each inline image directly. Do NOT call list_staging_photos().
+
+**Files on disk (staging folder or Cowork folder context):** Use the `file_path`
+parameter. Call list_staging_photos() first to get the paths.
 
 ## When you have file paths (staging folder or Cowork folder context)
 
@@ -229,47 +228,73 @@ def list_staging_photos() -> str:
     return "\n".join(lines)
 
 
+def _load_image_data(file_path: str | None, image_data: str | None) -> str:
+    """Return base64 image data from either a file path or inline base64."""
+    if file_path is not None:
+        return base64.b64encode(Path(file_path).read_bytes()).decode()
+    if image_data is not None:
+        return image_data
+    raise ValueError("Provide either file_path or image_data")
+
+
 @mcp.tool()
-def generate_card_preview(name: str, file_path: str) -> MCPImage:
+def generate_card_preview(
+    name: str,
+    file_path: str | None = None,
+    image_data: str | None = None,
+) -> MCPImage:
     """
     Process a photo and render it as an actual letter card preview.
     Call this for each candidate photo so the user can compare real cards.
 
+    Provide EITHER file_path (photo on disk) OR image_data (base64 of an inline image).
+
     Args:
         name: Person's name as it should appear on the card (e.g. 'Tata', 'mama')
-        file_path: Absolute path to the image file on disk (JPEG or PNG)
+        file_path: Absolute path to the image file on disk
+        image_data: Base64-encoded image (use when photo is inline in the conversation)
     """
-    image_data = base64.b64encode(Path(file_path).read_bytes()).decode()
-    photo = decode_and_process(image_data)
+    data  = _load_image_data(file_path, image_data)
+    photo = decode_and_process(data)
     card  = render_card(photo, name)
     return pil_to_mcp_image(card)
 
 
 @mcp.tool()
-def generate_comparison(name: str, file_paths: list[str]) -> MCPImage:
+def generate_comparison(
+    name: str,
+    file_paths: list[str] | None = None,
+    images_data: list[str] | None = None,
+) -> MCPImage:
     """
     Render multiple photos as cards side-by-side for easy comparison.
     Call this with your top 2–4 candidates after reviewing all previews.
-    Returns a single image showing all cards next to each other.
+
+    Provide EITHER file_paths (list of paths on disk) OR images_data (list of base64).
 
     Args:
         name: Person's name as it should appear on each card
         file_paths: List of absolute paths to the candidate photos
+        images_data: List of base64-encoded images (for inline photos)
     """
+    sources = file_paths if file_paths is not None else images_data
+    if not sources:
+        raise ValueError("Provide either file_paths or images_data")
+
     cards = []
-    for fp in file_paths:
-        image_data = base64.b64encode(Path(fp).read_bytes()).decode()
-        photo = decode_and_process(image_data)
+    for src in sources:
+        data  = _load_image_data(src if file_paths is not None else None,
+                                  src if images_data is not None else None)
+        photo = decode_and_process(data)
         cards.append(render_card(photo, name))
 
-    pad = 12
+    pad     = 12
     total_w = sum(c.width for c in cards) + pad * (len(cards) + 1)
     total_h = max(c.height for c in cards) + pad * 2
 
     grid = Image.new('RGB', (total_w, total_h), (230, 228, 215))
     x = pad
     for card in cards:
-        # Strip alpha before pasting
         if card.mode == 'RGBA':
             bg = Image.new('RGB', card.size, (230, 228, 215))
             bg.paste(card, mask=card.split()[-1])
@@ -281,17 +306,24 @@ def generate_comparison(name: str, file_paths: list[str]) -> MCPImage:
 
 
 @mcp.tool()
-def save_photo(name: str, file_path: str) -> str:
+def save_photo(
+    name: str,
+    file_path: str | None = None,
+    image_data: str | None = None,
+) -> str:
     """
     Save the chosen photo to the personal library.
     Call this once the user has confirmed which photo to use.
 
+    Provide EITHER file_path (photo on disk) OR image_data (base64 of an inline image).
+
     Args:
         name: Person's name — saved as {name}.png (e.g. 'tata' → tata.png)
         file_path: Absolute path to the chosen image file on disk
+        image_data: Base64-encoded image (use when photo is inline in the conversation)
     """
-    image_data = base64.b64encode(Path(file_path).read_bytes()).decode()
-    photo = decode_and_process(image_data)
+    data  = _load_image_data(file_path, image_data)
+    photo = decode_and_process(data)
     PERSONAL_DIR.mkdir(parents=True, exist_ok=True)
     out = PERSONAL_DIR / f"{name.lower()}.png"
     photo.save(out, 'PNG')

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -60,27 +60,34 @@ LETTER_COLORS = {
 mcp = FastMCP("lettercards", instructions="""
 You are helping select and process personal photos for Dutch letter learning cards.
 
-## Finding photos
+## IMPORTANT: these tools need files on disk
 
-Photos can come from two places — check both:
-1. **Dropped into this conversation**: In Cowork mode, dragged files land on disk and are
-   accessible by path. Look for them in the session uploads directory or any path the user
-   mentions.
-2. **Staging folder**: Call list_staging_photos() to check ~/.lettercards/staging/.
+These tools work with FILE PATHS only. They cannot access photos that are embedded
+inline in the conversation (e.g. images pasted or dragged directly into the chat).
 
-Use whichever has photos. If neither has any, ask the user to either drop photos in or
-copy them to the staging folder.
+If the user has dragged photos directly into the chat and you do not have file paths
+for them, say: "I can see your photos but I can't process inline images directly.
+Please copy the photos to ~/.lettercards/staging/ and I'll use those — or add the
+folder containing the photos to the Cowork context panel on the right."
+Do NOT call list_staging_photos() in this case — it won't help.
 
-## Workflow
+## When you have file paths (staging folder or Cowork folder context)
 
-1. Find the photos (see above)
-2. Call generate_card_preview() for each photo
-3. Then, based on how many photos there are:
-   - **1–3 photos**: Show all card previews individually — no comparison grid needed.
-     Recommend the best one directly.
-   - **4+ photos**: Pick the top 3 candidates, then ALWAYS call generate_comparison()
-     with those 3 automatically (never ask first). Then recommend the best one.
-4. When the user confirms, call save_photo() with the chosen file_path.
+**Step 1 — list:** Call list_staging_photos() to get file paths.
+
+**Step 2 — preview all:** Call generate_card_preview(name, file_path) for every photo.
+Do this silently — no text output yet.
+
+**Step 3 — compare or recommend:**
+- If there were 1–3 photos: recommend the best one directly with brief reasoning.
+- If there were 4+ photos: call generate_comparison(name, [top3_paths]) RIGHT NOW,
+  before writing any text. Do not describe your picks in words first. The comparison
+  call must happen before your text response.
+
+**Step 4 — recommend:** After the comparison (or after step 2 for 1-3 photos), write
+your recommendation with brief reasoning.
+
+**Step 5 — save:** When the user confirms, call save_photo(name, chosen_path).
 
 ## Quality criteria
 
@@ -89,9 +96,9 @@ A good card photo: face clearly visible, person recognisable, clean background p
 
 ## UI note
 
-Card preview images appear inside the "Used lettercards integration" section in Claude
-Desktop — not inline in the chat. Always tell the user to expand that section to see the
-cards: "Click 'Used lettercards integration' above to see the card previews."
+Card preview images appear inside the "Used lettercards integration" section — not
+inline in the chat. Always tell the user: "Click 'Used lettercards integration' above
+to see the card previews."
 """)
 
 # ── Image processing ─────────────────────────────────────────────────────────

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -13,6 +13,7 @@ Run via: venv-mcp/bin/python mcp_server.py
 
 import base64
 import io
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -23,7 +24,11 @@ from PIL import Image, ImageDraw, ImageEnhance, ImageFont, ImageOps
 # ── Paths ────────────────────────────────────────────────────────────────────
 
 REPO_DIR    = Path(__file__).parent
-PERSONAL_DIR = Path.home() / '.lettercards' / 'personal'
+PERSONAL_DIR = (
+    Path(os.environ['LETTERCARDS_PERSONAL_DIR'])
+    if 'LETTERCARDS_PERSONAL_DIR' in os.environ
+    else Path.home() / '.lettercards' / 'personal'
+)
 
 # ── Card rendering constants (matches generate.py) ──────────────────────────
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -62,10 +62,11 @@ You are helping select and process personal photos for Dutch letter learning car
 
 Workflow:
 1. Call list_staging_photos() to see what photos are in the staging folder
-2. Call generate_card_preview() for each candidate — pass the file_path from the listing
-3. Assess each rendered card: face clearly visible? crop good? recognisable?
-4. Recommend the best option with brief reasoning
-5. When the user confirms, call save_photo() with that file_path
+2. Call generate_card_preview() for each photo to review them all
+3. Pick your top 2–4 candidates based on face visibility and crop quality
+4. Call generate_comparison() with those top picks — this shows them side-by-side
+5. Recommend the best one with brief reasoning
+6. When the user confirms, call save_photo() with that file_path
 
 Photos must be on disk in the staging folder (~/.lettercards/staging/).
 Do NOT ask the user to upload photos inline — that does not work with these tools.
@@ -217,6 +218,41 @@ def generate_card_preview(name: str, file_path: str) -> MCPImage:
     photo = decode_and_process(image_data)
     card  = render_card(photo, name)
     return pil_to_mcp_image(card)
+
+
+@mcp.tool()
+def generate_comparison(name: str, file_paths: list[str]) -> MCPImage:
+    """
+    Render multiple photos as cards side-by-side for easy comparison.
+    Call this with your top 2–4 candidates after reviewing all previews.
+    Returns a single image showing all cards next to each other.
+
+    Args:
+        name: Person's name as it should appear on each card
+        file_paths: List of absolute paths to the candidate photos
+    """
+    cards = []
+    for fp in file_paths:
+        image_data = base64.b64encode(Path(fp).read_bytes()).decode()
+        photo = decode_and_process(image_data)
+        cards.append(render_card(photo, name))
+
+    pad = 12
+    total_w = sum(c.width for c in cards) + pad * (len(cards) + 1)
+    total_h = max(c.height for c in cards) + pad * 2
+
+    grid = Image.new('RGB', (total_w, total_h), (230, 228, 215))
+    x = pad
+    for card in cards:
+        # Strip alpha before pasting
+        if card.mode == 'RGBA':
+            bg = Image.new('RGB', card.size, (230, 228, 215))
+            bg.paste(card, mask=card.split()[-1])
+            card = bg
+        grid.paste(card, (x, pad))
+        x += card.width + pad
+
+    return pil_to_mcp_image(grid)
 
 
 @mcp.tool()

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -29,6 +29,11 @@ PERSONAL_DIR = (
     if 'LETTERCARDS_PERSONAL_DIR' in os.environ
     else Path.home() / '.lettercards' / 'personal'
 )
+STAGING_DIR = (
+    Path(os.environ['LETTERCARDS_STAGING_DIR'])
+    if 'LETTERCARDS_STAGING_DIR' in os.environ
+    else Path.home() / '.lettercards' / 'staging'
+)
 
 # ── Card rendering constants (matches generate.py) ──────────────────────────
 
@@ -55,11 +60,16 @@ LETTER_COLORS = {
 mcp = FastMCP("lettercards", instructions="""
 You are helping select and process personal photos for Dutch letter learning cards.
 
-When the user drops photos into the conversation:
-1. Call generate_card_preview() for each photo, passing the local file path — you'll see the actual card rendered inline
-2. Assess each card: is the face clearly visible? Is the crop good? Is it recognisable?
-3. Recommend the best option with brief reasoning
-4. When the user confirms, call save_photo() with the file path of the chosen photo
+Workflow:
+1. Call list_staging_photos() to see what photos are in the staging folder
+2. Call generate_card_preview() for each candidate — pass the file_path from the listing
+3. Assess each rendered card: face clearly visible? crop good? recognisable?
+4. Recommend the best option with brief reasoning
+5. When the user confirms, call save_photo() with that file_path
+
+Photos must be on disk in the staging folder (~/.lettercards/staging/).
+Do NOT ask the user to upload photos inline — that does not work with these tools.
+If staging is empty, tell the user to copy photos there first.
 
 The cards are for a toddler (Lena, ~2 years old) learning letter-sound associations.
 A good card photo: face clearly visible, person recognisable, clean background preferred.
@@ -172,6 +182,26 @@ def pil_to_mcp_image(img: Image.Image) -> MCPImage:
 
 
 # ── Tools ────────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+def list_staging_photos() -> str:
+    """
+    List photos available in the staging folder (~/.lettercards/staging/).
+    Call this first to see what photos are available before generating previews.
+    Returns a list of file paths you can pass to generate_card_preview().
+    """
+    if not STAGING_DIR.exists():
+        return f"Staging folder does not exist: {STAGING_DIR}\nAsk the user to create it and copy photos there."
+    extensions = {'.jpg', '.jpeg', '.png', '.heic', '.webp'}
+    photos = sorted(p for p in STAGING_DIR.iterdir() if p.suffix.lower() in extensions)
+    if not photos:
+        return f"No photos found in {STAGING_DIR}\nAsk the user to copy photos there first."
+    lines = [f"Found {len(photos)} photo(s) in {STAGING_DIR}:"]
+    for p in photos:
+        size_kb = p.stat().st_size // 1024
+        lines.append(f"  {p}  ({size_kb} KB)")
+    return "\n".join(lines)
+
 
 @mcp.tool()
 def generate_card_preview(name: str, file_path: str) -> MCPImage:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -60,27 +60,38 @@ LETTER_COLORS = {
 mcp = FastMCP("lettercards", instructions="""
 You are helping select and process personal photos for Dutch letter learning cards.
 
-Workflow — follow this exactly, no skipping steps:
-1. Call list_staging_photos() to see what photos are in the staging folder
-2. Call generate_card_preview() for each photo to review them all
-3. Pick your top 3 candidates based on face visibility and crop quality
-4. ALWAYS call generate_comparison() with those 3 picks — do this automatically, never ask first
-5. After showing the comparison, recommend the best one with brief reasoning
-6. When the user confirms, call save_photo() with that file_path
+## Finding photos
 
-Step 4 is mandatory. Never describe your top picks in text without first showing the comparison grid.
+Photos can come from two places — check both:
+1. **Dropped into this conversation**: In Cowork mode, dragged files land on disk and are
+   accessible by path. Look for them in the session uploads directory or any path the user
+   mentions.
+2. **Staging folder**: Call list_staging_photos() to check ~/.lettercards/staging/.
 
-Photos must be on disk in the staging folder (~/.lettercards/staging/).
-Do NOT ask the user to upload photos inline — that does not work with these tools.
-If staging is empty, tell the user to copy photos there first.
+Use whichever has photos. If neither has any, ask the user to either drop photos in or
+copy them to the staging folder.
+
+## Workflow
+
+1. Find the photos (see above)
+2. Call generate_card_preview() for each photo
+3. Then, based on how many photos there are:
+   - **1–3 photos**: Show all card previews individually — no comparison grid needed.
+     Recommend the best one directly.
+   - **4+ photos**: Pick the top 3 candidates, then ALWAYS call generate_comparison()
+     with those 3 automatically (never ask first). Then recommend the best one.
+4. When the user confirms, call save_photo() with the chosen file_path.
+
+## Quality criteria
 
 The cards are for a toddler (Lena, ~2 years old) learning letter-sound associations.
 A good card photo: face clearly visible, person recognisable, clean background preferred.
 
-Note: card preview images appear inside the "Used lettercards integration" section in
-Claude Desktop — not inline in the chat. Always tell the user to click that section header
-to expand it and see the cards. Say something like: "Click 'Used lettercards integration'
-above to see the card previews."
+## UI note
+
+Card preview images appear inside the "Used lettercards integration" section in Claude
+Desktop — not inline in the chat. Always tell the user to expand that section to see the
+cards: "Click 'Used lettercards integration' above to see the card previews."
 """)
 
 # ── Image processing ─────────────────────────────────────────────────────────

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -60,13 +60,15 @@ LETTER_COLORS = {
 mcp = FastMCP("lettercards", instructions="""
 You are helping select and process personal photos for Dutch letter learning cards.
 
-Workflow:
+Workflow — follow this exactly, no skipping steps:
 1. Call list_staging_photos() to see what photos are in the staging folder
 2. Call generate_card_preview() for each photo to review them all
-3. Pick your top 2–4 candidates based on face visibility and crop quality
-4. Call generate_comparison() with those top picks — this shows them side-by-side
-5. Recommend the best one with brief reasoning
+3. Pick your top 3 candidates based on face visibility and crop quality
+4. ALWAYS call generate_comparison() with those 3 picks — do this automatically, never ask first
+5. After showing the comparison, recommend the best one with brief reasoning
 6. When the user confirms, call save_photo() with that file_path
+
+Step 4 is mandatory. Never describe your top picks in text without first showing the comparison grid.
 
 Photos must be on disk in the staging folder (~/.lettercards/staging/).
 Do NOT ask the user to upload photos inline — that does not work with these tools.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2,28 +2,26 @@
 """
 Lettercards MCP Server
 
-Exposes tools for Claude Desktop to guide the personal photo card workflow:
-- Drop photos into the Claude Desktop conversation
-- Claude calls generate_card_preview() to see the actual card
-- Claude calls save_photo() when you confirm
+Tools for any MCP-capable AI to guide the personal photo card workflow:
+- Open a native file picker to select candidate photos
+- Preview candidates as a numbered thumbnail grid (AI selects best 2-3)
+- Render selected photos as actual lettercards for final comparison
+- Save the chosen photo to the personal library
 
 Setup: see docs/mcp-setup.md
 Run via: venv-mcp/bin/python mcp_server.py
 """
 
-import base64
 import io
 import os
-import subprocess
-import sys
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP, Image as MCPImage
 from PIL import Image, ImageDraw, ImageEnhance, ImageFont, ImageOps
 
-# ── Paths ────────────────────────────────────────────────────────────────────
+# ── Paths ─────────────────────────────────────────────────────────────────────
 
-REPO_DIR    = Path(__file__).parent
+REPO_DIR     = Path(__file__).parent
 PERSONAL_DIR = (
     Path(os.environ['LETTERCARDS_PERSONAL_DIR'])
     if 'LETTERCARDS_PERSONAL_DIR' in os.environ
@@ -34,10 +32,11 @@ STAGING_DIR = (
     if 'LETTERCARDS_STAGING_DIR' in os.environ
     else Path.home() / '.lettercards' / 'staging'
 )
+SUPPORTED_FORMATS = {'.jpg', '.jpeg', '.png', '.heic', '.webp'}
 
-# ── Card rendering constants (matches generate.py) ──────────────────────────
+# ── Card rendering constants (matches generate.py) ────────────────────────────
 
-CARD_W, CARD_H = 300, 450          # px at preview resolution
+CARD_W, CARD_H = 300, 450
 BG_PICTURE     = (245, 242, 225)   # warm cream
 CORNER_R       = 16
 DEFAULT_COLOR  = (220, 100, 40)    # orange fallback
@@ -55,58 +54,75 @@ LETTER_COLORS = {
     'y': (80,  40,  200), 'z': (60,  180, 140),
 }
 
-# ── MCP server ───────────────────────────────────────────────────────────────
+# ── Fonts (cross-platform) ────────────────────────────────────────────────────
+
+# Searched in order; first match wins. PIL default is the final fallback.
+_FONT_CANDIDATES = [
+    str(REPO_DIR / "fonts" / "DejaVuSans-Bold.ttf"),           # in-repo (any OS)
+    # macOS
+    "/System/Library/Fonts/Supplemental/Arial Rounded Bold.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    # Linux
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+    # Windows
+    "C:/Windows/Fonts/arialbd.ttf",
+    "C:/Windows/Fonts/calibrib.ttf",
+]
+
+
+def _load_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    for path in _FONT_CANDIDATES:
+        if Path(path).exists():
+            try:
+                return ImageFont.truetype(path, size)
+            except Exception:
+                continue
+    return ImageFont.load_default()
+
+
+# ── MCP server ────────────────────────────────────────────────────────────────
 
 mcp = FastMCP("lettercards", instructions="""
-You are helping select and process personal photos for Dutch letter learning cards.
+You are helping select and process personal photos for letter learning cards.
 
-## Two input modes
+## Workflow
 
-These tools accept photos in two ways — use whichever applies:
+**Step 1 — pick photos:** Call pick_photos(name). A native file picker opens and
+the user selects candidate photos from anywhere on their computer.
+The tool returns a numbered list of absolute file paths.
 
-**Inline images (dropped into the chat):** Use the `image_data` parameter — pass the
-base64 of each inline image directly. Do NOT call list_staging_photos().
+**Step 2 — evaluate and compare:**
+- 1–3 photos selected: call generate_comparison(name, file_paths) immediately.
+- 4+ photos selected: call generate_photo_grid(file_paths) first. Evaluate the
+  returned grid image with your vision — look for face clearly visible, clean
+  background, good lighting. Pick the best 2–3, then call
+  generate_comparison(name, best_file_paths) with only those.
 
-**Files on disk (staging folder or Cowork folder context):** Use the `file_path`
-parameter. Call list_staging_photos() first to get the paths.
+**Step 3 — present:** After generate_comparison returns, tell the user to expand
+the tool output section in their AI client to see the rendered card previews.
+Add a brief note on each candidate (lighting, face visibility, background).
 
-## When you have file paths (staging folder or Cowork folder context)
-
-**Step 1 — list:** Call list_staging_photos() to get file paths.
-
-**Step 2 — preview all:** Call generate_card_preview(name, file_path) for every photo.
-Do this silently — no text output yet.
-
-**Step 3 — compare or recommend:**
-- If there were 1–3 photos: recommend the best one directly with brief reasoning.
-- If there were 4+ photos: call generate_comparison(name, [top3_paths]) RIGHT NOW,
-  before writing any text. Do not describe your picks in words first. The comparison
-  call must happen before your text response.
-
-**Step 4 — recommend:** After the comparison (or after step 2 for 1-3 photos), write
-your recommendation with brief reasoning.
-
-**Step 5 — save:** When the user confirms, call save_photo(name, chosen_path).
+**Step 4 — save:** When the user confirms a choice, call save_photo(name, file_path)
+with the path of the chosen photo. Report the path where it was saved and the
+generate command to rebuild the PDF.
 
 ## Quality criteria
 
-The cards are for a toddler (Lena, ~2 years old) learning letter-sound associations.
-A good card photo: face clearly visible, person recognisable, clean background preferred.
+A good card photo: face clearly visible, person recognisable, clean or simple
+background preferred. Cards are for a toddler learning letter-sound associations.
 
-## UI note
+## Fallback: directory listing
 
-Card preview images appear inside the "Used lettercards integration" section — not
-inline in the chat. Always tell the user: "Click 'Used lettercards integration' above
-to see the card previews."
+If the file picker cannot open (headless / no display), call
+pick_photos(name, directory="/path/to/photos") to list photos from a directory.
 """)
 
-# ── Image processing ─────────────────────────────────────────────────────────
 
-def decode_and_process(image_data: str, size: int = 400) -> Image.Image:
-    """Decode base64 image, correct orientation, crop to square, auto-enhance."""
-    img = Image.open(io.BytesIO(base64.b64decode(image_data)))
+# ── Image processing ──────────────────────────────────────────────────────────
 
-    # Normalise colour mode
+def _normalise(img: Image.Image) -> Image.Image:
+    """Normalise colour mode and correct EXIF orientation."""
     if img.mode in ('RGBA', 'P'):
         bg = Image.new('RGB', img.size, (255, 255, 255))
         img = img.convert('RGBA')
@@ -115,32 +131,52 @@ def decode_and_process(image_data: str, size: int = 400) -> Image.Image:
     elif img.mode != 'RGB':
         img = img.convert('RGB')
 
-    # EXIF orientation
     try:
         from PIL import ExifTags
-        for tag in ExifTags.TAGS:
-            if ExifTags.TAGS[tag] == 'Orientation':
-                break
+        orientation_tag = next(
+            tag for tag, name in ExifTags.TAGS.items() if name == 'Orientation'
+        )
         exif = img._getexif()
         if exif:
-            val = exif.get(tag)
+            val = exif.get(orientation_tag)
             if val == 3:   img = img.rotate(180, expand=True)
             elif val == 6: img = img.rotate(270, expand=True)
             elif val == 8: img = img.rotate(90,  expand=True)
     except Exception:
         pass
 
+    return img
+
+
+def _crop_and_enhance(img: Image.Image, size: int = 400) -> Image.Image:
+    """Crop to square, resize, auto-enhance."""
     w, h = img.size
     if h > w:
-        img = img.crop((0, 0, w, w))          # portrait: top crop
+        img = img.crop((0, 0, w, w))               # portrait: top crop
     else:
         s = min(w, h)
         img = img.crop(((w-s)//2, (h-s)//2, (w+s)//2, (h+s)//2))  # landscape: centre
-
     img = img.resize((size, size), Image.LANCZOS)
     img = ImageOps.autocontrast(img, cutoff=2)
     img = ImageEnhance.Sharpness(img).enhance(1.3)
     return img
+
+
+def load_and_process(file_path: str, size: int = 400) -> Image.Image:
+    """Load from file, correct orientation, crop to square, auto-enhance."""
+    img = Image.open(Path(file_path).expanduser())
+    return _crop_and_enhance(_normalise(img), size)
+
+
+def decode_and_process(image_data: str, size: int = 400) -> Image.Image:
+    """Decode base64 image, correct orientation, crop to square, auto-enhance.
+
+    Kept for backward compatibility and testing.
+    New tools use load_and_process() directly.
+    """
+    import base64
+    img = Image.open(io.BytesIO(base64.b64decode(image_data)))
+    return _crop_and_enhance(_normalise(img), size)
 
 
 def render_card(photo: Image.Image, word: str) -> Image.Image:
@@ -156,40 +192,30 @@ def render_card(photo: Image.Image, word: str) -> Image.Image:
     ImageDraw.Draw(mask).rounded_rectangle([0, 0, CARD_W-1, CARD_H-1], radius=CORNER_R, fill=255)
     card.putalpha(mask)
 
-    # Photo — centred in upper 68% of card
-    pad        = 16
-    img_size   = CARD_W - 2 * pad
-    photo_rs   = photo.resize((img_size, img_size), Image.LANCZOS)
-    photo_y    = int(CARD_H * 0.06)
+    # Photo — upper portion of card
+    pad      = 16
+    img_size = CARD_W - 2 * pad
+    photo_rs = photo.resize((img_size, img_size), Image.LANCZOS)
+    photo_y  = int(CARD_H * 0.06)
     card.paste(photo_rs, (pad, photo_y))
 
     # Word label — first letter in accent colour, rest dark
-    try:
-        font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 28)
-    except Exception:
-        font = ImageFont.load_default()
+    font       = _load_font(28)
+    badge_font = _load_font(14)
+    word_y     = int(CARD_H * 0.80)
+    first      = word[0]
+    rest       = word[1:]
 
-    word_y = int(CARD_H * 0.80)
-    first  = word[0]
-    rest   = word[1:]
-
-    # Measure to centre
     bbox_first = draw.textbbox((0, 0), first, font=font)
     bbox_rest  = draw.textbbox((0, 0), rest,  font=font)
     w_first    = bbox_first[2] - bbox_first[0]
     w_rest     = bbox_rest[2]  - bbox_rest[0]
-    total_w    = w_first + w_rest
-    text_x     = (CARD_W - total_w) // 2
+    text_x     = (CARD_W - w_first - w_rest) // 2
 
-    draw.text((text_x,           word_y), first, fill=color,         font=font)
-    draw.text((text_x + w_first, word_y), rest,  fill=(40, 40, 40),  font=font)
+    draw.text((text_x,           word_y), first, fill=color,        font=font)
+    draw.text((text_x + w_first, word_y), rest,  fill=(40, 40, 40), font=font)
 
-    # Small letter badge — top-left corner
-    try:
-        badge_font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 14)
-    except Exception:
-        badge_font = ImageFont.load_default()
-
+    # Letter badge — top-left corner
     badge_r = 12
     draw.ellipse([8, 8, 8+badge_r*2, 8+badge_r*2], fill=color)
     bb = draw.textbbox((0, 0), letter, font=badge_font)
@@ -200,134 +226,227 @@ def render_card(photo: Image.Image, word: str) -> Image.Image:
     return card
 
 
-def pil_to_mcp_image(img: Image.Image) -> MCPImage:
+def _pil_to_mcp(img: Image.Image) -> MCPImage:
     buf = io.BytesIO()
     img.save(buf, format='PNG')
     return MCPImage(data=buf.getvalue(), format='png')
 
 
-# ── Tools ────────────────────────────────────────────────────────────────────
+def _open_file_picker(title: str) -> list[str]:
+    """Open a native OS file picker dialog. Returns list of selected paths."""
+    import tkinter as tk
+    from tkinter import filedialog
+
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        root.wm_attributes('-topmost', True)  # bring dialog to front on macOS/Windows
+    except Exception:
+        pass
+    paths = filedialog.askopenfilenames(
+        title=title,
+        filetypes=[
+            ("Images", "*.jpg *.jpeg *.png *.heic *.webp *.JPG *.JPEG *.PNG *.HEIC *.WEBP"),
+            ("All files", "*.*"),
+        ],
+    )
+    root.destroy()
+    return list(paths)
+
+
+# ── Tools ─────────────────────────────────────────────────────────────────────
 
 @mcp.tool()
-def list_staging_photos() -> str:
+def pick_photos(name: str, directory: str | None = None) -> str:
     """
-    List photos available in the staging folder (~/.lettercards/staging/).
-    Call this first to see what photos are available before generating previews.
-    Returns a list of file paths you can pass to generate_card_preview().
+    Select candidate photos for a letter card.
+
+    Opens a native OS file picker dialog so the user can choose photos from
+    anywhere on their computer. Returns a numbered list of absolute paths that
+    you can pass directly to generate_photo_grid() or generate_comparison().
+
+    If the file picker is unavailable (headless environment / no display),
+    provide a directory path and this tool will list all photos found there.
+
+    Args:
+        name:      Person's name — used in the dialog title.
+        directory: Optional. List photos from this directory instead of
+                   opening a picker dialog. Use in headless environments or
+                   when photos are already in a known folder.
     """
-    if not STAGING_DIR.exists():
-        return f"Staging folder does not exist: {STAGING_DIR}\nAsk the user to create it and copy photos there."
-    extensions = {'.jpg', '.jpeg', '.png', '.heic', '.webp'}
-    photos = sorted(p for p in STAGING_DIR.iterdir() if p.suffix.lower() in extensions)
-    if not photos:
-        return f"No photos found in {STAGING_DIR}\nAsk the user to copy photos there first."
-    lines = [f"Found {len(photos)} photo(s) in {STAGING_DIR}:"]
-    for p in photos:
-        size_kb = p.stat().st_size // 1024
-        lines.append(f"  {p}  ({size_kb} KB)")
+    if directory is not None:
+        d = Path(directory).expanduser()
+        if not d.is_dir():
+            return f"Directory not found: {d}"
+        photos = sorted(p for p in d.iterdir() if p.suffix.lower() in SUPPORTED_FORMATS)
+        if not photos:
+            return f"No photos found in {d}."
+        lines = [f"Found {len(photos)} photo(s) in {d}:"]
+        for i, p in enumerate(photos, 1):
+            lines.append(f"  {i}. {p}")
+        return "\n".join(lines)
+
+    try:
+        paths = _open_file_picker(f"Select candidate photos for '{name}'")
+    except Exception as exc:
+        return (
+            f"File picker unavailable ({exc}).\n"
+            f"Use: pick_photos(name='{name}', directory='/path/to/photos')"
+        )
+
+    if not paths:
+        return "No photos selected."
+
+    lines = [f"Selected {len(paths)} photo(s):"]
+    for i, p in enumerate(paths, 1):
+        lines.append(f"  {i}. {p}")
     return "\n".join(lines)
 
 
-def _load_image_data(file_path: str | None, image_data: str | None) -> str:
-    """Return base64 image data from either a file path or inline base64."""
-    if file_path is not None:
-        return base64.b64encode(Path(file_path).read_bytes()).decode()
-    if image_data is not None:
-        return image_data
-    raise ValueError("Provide either file_path or image_data")
+@mcp.tool()
+def generate_photo_grid(file_paths: list[str]) -> MCPImage:
+    """
+    Render a numbered thumbnail grid of the raw candidate photos.
+
+    Use this when 4 or more photos were selected so you can evaluate them
+    with your vision before deciding which 2–3 to render as full lettercards.
+
+    Evaluate the grid and pick the best candidates based on:
+    - Face clearly visible and well-framed
+    - Clean or simple background
+    - Good lighting — no heavy shadows or overexposure
+
+    The numbers in the grid match the position in file_paths (1-indexed).
+    Pass the corresponding paths of your picks to generate_comparison().
+
+    Args:
+        file_paths: Ordered list of absolute paths (as returned by pick_photos).
+    """
+    CELL  = 200
+    PAD   = 8
+    COLS  = 3
+    LABEL = 28
+    font  = _load_font(13)
+    fn    = _load_font(18)
+
+    rows   = (len(file_paths) + COLS - 1) // COLS
+    cell_w = CELL + PAD * 2
+    cell_h = CELL + LABEL + PAD * 2
+    grid   = Image.new('RGB', (COLS * cell_w, rows * cell_h), (230, 228, 215))
+    draw   = ImageDraw.Draw(grid)
+
+    for i, path_str in enumerate(file_paths):
+        col = i % COLS
+        row = i // COLS
+        x   = col * cell_w + PAD
+        y   = row * cell_h + PAD
+        num = str(i + 1)
+
+        try:
+            thumb = _normalise(Image.open(Path(path_str).expanduser()))
+            tw, th = thumb.size
+            s = min(tw, th)
+            thumb = thumb.crop(((tw-s)//2, (th-s)//2, (tw+s)//2, (th+s)//2))
+            thumb = thumb.resize((CELL, CELL), Image.LANCZOS)
+            grid.paste(thumb, (x, y))
+        except Exception:
+            draw.rectangle([x, y, x+CELL, y+CELL], fill=(180, 175, 165))
+            draw.text((x+4, y+4), f"error: {Path(path_str).name}", fill=(80, 70, 60), font=font)
+
+        # Number badge
+        draw.rectangle([x, y, x+24, y+22], fill=DEFAULT_COLOR)
+        draw.text((x+3, y+2), num, fill=(255, 255, 255), font=fn)
+
+        # Filename label
+        short = Path(path_str).name
+        if len(short) > 30:
+            short = short[:27] + '...'
+        draw.text((x+2, y+CELL+4), short, fill=(60, 55, 50), font=font)
+
+        # Border
+        draw.rectangle([x, y, x+CELL, y+CELL], outline=(170, 165, 155))
+
+    return _pil_to_mcp(grid)
 
 
 @mcp.tool()
-def generate_card_preview(
-    name: str,
-    file_path: str | None = None,
-    image_data: str | None = None,
-) -> MCPImage:
+def generate_comparison(name: str, file_paths: list[str]) -> MCPImage:
     """
-    Process a photo and render it as an actual letter card preview.
-    Call this for each candidate photo so the user can compare real cards.
+    Render 2–4 photos as actual lettercards side-by-side for final comparison.
 
-    Provide EITHER file_path (photo on disk) OR image_data (base64 of an inline image).
+    Call this after selecting candidates — either directly from the pick_photos
+    result (1–3 photos) or after narrowing down with generate_photo_grid (4+).
+
+    The returned image shows each photo rendered as a real lettercard so the
+    user can see exactly how it will look when printed.
 
     Args:
-        name: Person's name as it should appear on the card (e.g. 'Tata', 'mama')
-        file_path: Absolute path to the image file on disk
-        image_data: Base64-encoded image (use when photo is inline in the conversation)
+        name:       Person's name as it will appear on the card label.
+        file_paths: 1–4 absolute paths to the candidate photos.
     """
-    data  = _load_image_data(file_path, image_data)
-    photo = decode_and_process(data)
-    card  = render_card(photo, name)
-    return pil_to_mcp_image(card)
-
-
-@mcp.tool()
-def generate_comparison(
-    name: str,
-    file_paths: list[str] | None = None,
-    images_data: list[str] | None = None,
-) -> MCPImage:
-    """
-    Render multiple photos as cards side-by-side for easy comparison.
-    Call this with your top 2–4 candidates after reviewing all previews.
-
-    Provide EITHER file_paths (list of paths on disk) OR images_data (list of base64).
-
-    Args:
-        name: Person's name as it should appear on each card
-        file_paths: List of absolute paths to the candidate photos
-        images_data: List of base64-encoded images (for inline photos)
-    """
-    sources = file_paths if file_paths is not None else images_data
-    if not sources:
-        raise ValueError("Provide either file_paths or images_data")
-
+    PAD   = 12
     cards = []
-    for src in sources:
-        data  = _load_image_data(src if file_paths is not None else None,
-                                  src if images_data is not None else None)
-        photo = decode_and_process(data)
+    for path_str in file_paths:
+        photo = load_and_process(path_str)
         cards.append(render_card(photo, name))
 
-    pad     = 12
-    total_w = sum(c.width for c in cards) + pad * (len(cards) + 1)
-    total_h = max(c.height for c in cards) + pad * 2
+    total_w = sum(c.width for c in cards) + PAD * (len(cards) + 1)
+    total_h = max(c.height for c in cards) + PAD * 2
+    grid    = Image.new('RGB', (total_w, total_h), (230, 228, 215))
 
-    grid = Image.new('RGB', (total_w, total_h), (230, 228, 215))
-    x = pad
+    x = PAD
     for card in cards:
         if card.mode == 'RGBA':
             bg = Image.new('RGB', card.size, (230, 228, 215))
             bg.paste(card, mask=card.split()[-1])
             card = bg
-        grid.paste(card, (x, pad))
-        x += card.width + pad
+        grid.paste(card, (x, PAD))
+        x += card.width + PAD
 
-    return pil_to_mcp_image(grid)
+    return _pil_to_mcp(grid)
 
 
 @mcp.tool()
-def save_photo(
-    name: str,
-    file_path: str | None = None,
-    image_data: str | None = None,
-) -> str:
+def save_photo(name: str, file_path: str) -> str:
     """
     Save the chosen photo to the personal library.
-    Call this once the user has confirmed which photo to use.
 
-    Provide EITHER file_path (photo on disk) OR image_data (base64 of an inline image).
+    Call this once the user has confirmed which photo to use. The photo is
+    processed (orientation-corrected, cropped to square, auto-enhanced) and
+    saved to the personal photo directory.
 
     Args:
-        name: Person's name — saved as {name}.png (e.g. 'tata' → tata.png)
-        file_path: Absolute path to the chosen image file on disk
-        image_data: Base64-encoded image (use when photo is inline in the conversation)
+        name:      Person's name — saved as {name}.png (lowercased).
+        file_path: Absolute path to the chosen photo on disk.
     """
-    data  = _load_image_data(file_path, image_data)
-    photo = decode_and_process(data)
+    photo = load_and_process(file_path)
     PERSONAL_DIR.mkdir(parents=True, exist_ok=True)
     out = PERSONAL_DIR / f"{name.lower()}.png"
     photo.save(out, 'PNG')
-    return f"Saved to {out}. Run: python generate.py --letters {name[0].lower()}"
+    return (
+        f"Saved to {out}\n"
+        f"To regenerate the PDF: lettercards generate --letters {name[0].lower()}"
+    )
+
+
+@mcp.tool()
+def list_staging_photos() -> str:
+    """
+    List photos in the staging folder (~/.lettercards/staging/).
+
+    Fallback for users who prefer copying photos to a staging folder rather
+    than using the file picker. Returns a numbered list of paths you can pass
+    to generate_comparison() or generate_photo_grid().
+    """
+    if not STAGING_DIR.exists():
+        return f"Staging folder not found: {STAGING_DIR}"
+    photos = sorted(p for p in STAGING_DIR.iterdir() if p.suffix.lower() in SUPPORTED_FORMATS)
+    if not photos:
+        return f"No photos in {STAGING_DIR}."
+    lines = [f"Found {len(photos)} photo(s) in {STAGING_DIR}:"]
+    for i, p in enumerate(photos, 1):
+        lines.append(f"  {i}. {p}  ({p.stat().st_size // 1024} KB)")
+    return "\n".join(lines)
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Lettercards MCP Server
+
+Exposes tools for Claude Desktop to guide the personal photo card workflow:
+- Drop photos into the Claude Desktop conversation
+- Claude calls generate_card_preview() to see the actual card
+- Claude calls save_photo() when you confirm
+
+Setup: see docs/mcp-setup.md
+Run via: venv-mcp/bin/python mcp_server.py
+"""
+
+import base64
+import io
+import subprocess
+import sys
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP, Image as MCPImage
+from PIL import Image, ImageDraw, ImageEnhance, ImageFont, ImageOps
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+
+REPO_DIR    = Path(__file__).parent
+PERSONAL_DIR = Path.home() / '.lettercards' / 'personal'
+
+# ── Card rendering constants (matches generate.py) ──────────────────────────
+
+CARD_W, CARD_H = 300, 450          # px at preview resolution
+BG_PICTURE     = (245, 242, 225)   # warm cream
+CORNER_R       = 16
+DEFAULT_COLOR  = (220, 100, 40)    # orange fallback
+
+# Letter accent colours — same palette as generate.py
+LETTER_COLORS = {
+    'a': (220, 80,  50),  'b': (50,  120, 200), 'c': (180, 140, 40),
+    'd': (80,  160, 80),  'e': (200, 80,  150), 'f': (100, 60,  180),
+    'g': (220, 120, 40),  'h': (40,  160, 160), 'i': (180, 60,  60),
+    'j': (60,  140, 100), 'k': (160, 40,  120), 'l': (40,  100, 200),
+    'm': (200, 140, 40),  'n': (80,  60,  180), 'o': (60,  160, 120),
+    'p': (180, 80,  40),  'q': (120, 40,  160), 'r': (40,  140, 60),
+    's': (200, 60,  100), 't': (60,  120, 200), 'u': (160, 160, 40),
+    'v': (120, 80,  160), 'w': (40,  160, 80),  'x': (200, 100, 60),
+    'y': (80,  40,  200), 'z': (60,  180, 140),
+}
+
+# ── MCP server ───────────────────────────────────────────────────────────────
+
+mcp = FastMCP("lettercards", instructions="""
+You are helping select and process personal photos for Dutch letter learning cards.
+
+When the user drops photos into the conversation:
+1. Call generate_card_preview() for each photo — you'll see the actual card
+2. Assess each card: is the face clearly visible? Is the crop good? Is it recognisable?
+3. Recommend the best option with brief reasoning
+4. When the user confirms, call save_photo() to save it to their personal library
+
+The cards are for a toddler (Lena, ~2 years old) learning letter-sound associations.
+A good card photo: face clearly visible, person recognisable, clean background preferred.
+""")
+
+# ── Image processing ─────────────────────────────────────────────────────────
+
+def decode_and_process(image_data: str, size: int = 400) -> Image.Image:
+    """Decode base64 image, correct orientation, crop to square, auto-enhance."""
+    img = Image.open(io.BytesIO(base64.b64decode(image_data)))
+
+    # Normalise colour mode
+    if img.mode in ('RGBA', 'P'):
+        bg = Image.new('RGB', img.size, (255, 255, 255))
+        img = img.convert('RGBA')
+        bg.paste(img, mask=img.split()[-1])
+        img = bg
+    elif img.mode != 'RGB':
+        img = img.convert('RGB')
+
+    # EXIF orientation
+    try:
+        from PIL import ExifTags
+        for tag in ExifTags.TAGS:
+            if ExifTags.TAGS[tag] == 'Orientation':
+                break
+        exif = img._getexif()
+        if exif:
+            val = exif.get(tag)
+            if val == 3:   img = img.rotate(180, expand=True)
+            elif val == 6: img = img.rotate(270, expand=True)
+            elif val == 8: img = img.rotate(90,  expand=True)
+    except Exception:
+        pass
+
+    w, h = img.size
+    if h > w:
+        img = img.crop((0, 0, w, w))          # portrait: top crop
+    else:
+        s = min(w, h)
+        img = img.crop(((w-s)//2, (h-s)//2, (w+s)//2, (h+s)//2))  # landscape: centre
+
+    img = img.resize((size, size), Image.LANCZOS)
+    img = ImageOps.autocontrast(img, cutoff=2)
+    img = ImageEnhance.Sharpness(img).enhance(1.3)
+    return img
+
+
+def render_card(photo: Image.Image, word: str) -> Image.Image:
+    """Render a picture card with the given photo and word label."""
+    letter = word[0].lower()
+    color  = LETTER_COLORS.get(letter, DEFAULT_COLOR)
+
+    card = Image.new('RGB', (CARD_W, CARD_H), BG_PICTURE)
+    draw = ImageDraw.Draw(card)
+
+    # Rounded-rect background mask
+    mask = Image.new('L', (CARD_W, CARD_H), 0)
+    ImageDraw.Draw(mask).rounded_rectangle([0, 0, CARD_W-1, CARD_H-1], radius=CORNER_R, fill=255)
+    card.putalpha(mask)
+
+    # Photo — centred in upper 68% of card
+    pad        = 16
+    img_size   = CARD_W - 2 * pad
+    photo_rs   = photo.resize((img_size, img_size), Image.LANCZOS)
+    photo_y    = int(CARD_H * 0.06)
+    card.paste(photo_rs, (pad, photo_y))
+
+    # Word label — first letter in accent colour, rest dark
+    try:
+        font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 28)
+    except Exception:
+        font = ImageFont.load_default()
+
+    word_y = int(CARD_H * 0.80)
+    first  = word[0]
+    rest   = word[1:]
+
+    # Measure to centre
+    bbox_first = draw.textbbox((0, 0), first, font=font)
+    bbox_rest  = draw.textbbox((0, 0), rest,  font=font)
+    w_first    = bbox_first[2] - bbox_first[0]
+    w_rest     = bbox_rest[2]  - bbox_rest[0]
+    total_w    = w_first + w_rest
+    text_x     = (CARD_W - total_w) // 2
+
+    draw.text((text_x,           word_y), first, fill=color,         font=font)
+    draw.text((text_x + w_first, word_y), rest,  fill=(40, 40, 40),  font=font)
+
+    # Small letter badge — top-left corner
+    try:
+        badge_font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 14)
+    except Exception:
+        badge_font = ImageFont.load_default()
+
+    badge_r = 12
+    draw.ellipse([8, 8, 8+badge_r*2, 8+badge_r*2], fill=color)
+    bb = draw.textbbox((0, 0), letter, font=badge_font)
+    bx = 8 + badge_r - (bb[2]-bb[0])//2
+    by = 8 + badge_r - (bb[3]-bb[1])//2
+    draw.text((bx, by), letter, fill=(255, 255, 255), font=badge_font)
+
+    return card
+
+
+def pil_to_mcp_image(img: Image.Image) -> MCPImage:
+    buf = io.BytesIO()
+    img.save(buf, format='PNG')
+    return MCPImage(data=buf.getvalue(), format='png')
+
+
+# ── Tools ────────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+def generate_card_preview(name: str, image_data: str) -> Image.Image:
+    """
+    Process a photo and render it as an actual letter card preview.
+    Call this for each candidate photo so the user can compare real cards.
+
+    Args:
+        name: Person's name as it should appear on the card (e.g. 'Tata', 'mama')
+        image_data: Base64-encoded image (JPEG or PNG)
+    """
+    photo = decode_and_process(image_data)
+    card  = render_card(photo, name)
+    return pil_to_mcp_image(card)
+
+
+@mcp.tool()
+def save_photo(name: str, image_data: str) -> str:
+    """
+    Save the chosen photo to the personal library.
+    Call this once the user has confirmed which photo to use.
+
+    Args:
+        name: Person's name — saved as {name}.png (e.g. 'tata' → tata.png)
+        image_data: Base64-encoded image of the chosen photo
+    """
+    photo = decode_and_process(image_data)
+    PERSONAL_DIR.mkdir(parents=True, exist_ok=True)
+    out = PERSONAL_DIR / f"{name.lower()}.png"
+    photo.save(out, 'PNG')
+    return f"Saved to {out}. Run: python generate.py --letters {name[0].lower()}"
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+if __name__ == '__main__':
+    mcp.run(transport='stdio')

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -56,10 +56,10 @@ mcp = FastMCP("lettercards", instructions="""
 You are helping select and process personal photos for Dutch letter learning cards.
 
 When the user drops photos into the conversation:
-1. Call generate_card_preview() for each photo — you'll see the actual card
+1. Call generate_card_preview() for each photo, passing the local file path — you'll see the actual card rendered inline
 2. Assess each card: is the face clearly visible? Is the crop good? Is it recognisable?
 3. Recommend the best option with brief reasoning
-4. When the user confirms, call save_photo() to save it to their personal library
+4. When the user confirms, call save_photo() with the file path of the chosen photo
 
 The cards are for a toddler (Lena, ~2 years old) learning letter-sound associations.
 A good card photo: face clearly visible, person recognisable, clean background preferred.
@@ -174,30 +174,32 @@ def pil_to_mcp_image(img: Image.Image) -> MCPImage:
 # ── Tools ────────────────────────────────────────────────────────────────────
 
 @mcp.tool()
-def generate_card_preview(name: str, image_data: str) -> Image.Image:
+def generate_card_preview(name: str, file_path: str) -> MCPImage:
     """
     Process a photo and render it as an actual letter card preview.
     Call this for each candidate photo so the user can compare real cards.
 
     Args:
         name: Person's name as it should appear on the card (e.g. 'Tata', 'mama')
-        image_data: Base64-encoded image (JPEG or PNG)
+        file_path: Absolute path to the image file on disk (JPEG or PNG)
     """
+    image_data = base64.b64encode(Path(file_path).read_bytes()).decode()
     photo = decode_and_process(image_data)
     card  = render_card(photo, name)
     return pil_to_mcp_image(card)
 
 
 @mcp.tool()
-def save_photo(name: str, image_data: str) -> str:
+def save_photo(name: str, file_path: str) -> str:
     """
     Save the chosen photo to the personal library.
     Call this once the user has confirmed which photo to use.
 
     Args:
         name: Person's name — saved as {name}.png (e.g. 'tata' → tata.png)
-        image_data: Base64-encoded image of the chosen photo
+        file_path: Absolute path to the chosen image file on disk
     """
+    image_data = base64.b64encode(Path(file_path).read_bytes()).decode()
     photo = decode_and_process(image_data)
     PERSONAL_DIR.mkdir(parents=True, exist_ok=True)
     out = PERSONAL_DIR / f"{name.lower()}.png"

--- a/process_photo.py
+++ b/process_photo.py
@@ -17,9 +17,10 @@ The output folder is:  ~/.lettercards/personal/
 
 import argparse
 import os
+import subprocess
 import sys
 from pathlib import Path
-from PIL import Image
+from PIL import Image, ImageDraw, ImageEnhance, ImageFont, ImageOps
 
 # ── Configuration ──────────────────────────────────────────────────────
 
@@ -153,6 +154,99 @@ def process_image(source_path, output_size=DEFAULT_SIZE):
     return resized
 
 
+def auto_enhance(img):
+    """Mild automatic enhancement: auto-contrast + slight sharpness boost."""
+    img = ImageOps.autocontrast(img, cutoff=2)
+    img = ImageEnhance.Sharpness(img).enhance(1.3)
+    return img
+
+
+def make_comparison_grid(entries, cell_size=280, cols=3):
+    """
+    entries: list of (number_label, filename_label, PIL Image)
+    Returns a single PIL Image grid.
+    """
+    label_h = 38
+    pad = 6
+    cell_w = cell_size + pad * 2
+    cell_h = cell_size + label_h + pad * 2
+    rows = (len(entries) + cols - 1) // cols
+
+    bg = (245, 242, 235)
+    grid = Image.new('RGB', (cols * cell_w, rows * cell_h), bg)
+    draw = ImageDraw.Draw(grid)
+
+    try:
+        font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 13)
+        font_num = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 18)
+    except Exception:
+        font = font_num = ImageFont.load_default()
+
+    for i, (num_label, file_label, thumb) in enumerate(entries):
+        col = i % cols
+        row = i // cols
+        x = col * cell_w + pad
+        y = row * cell_h + pad
+
+        # Photo
+        grid.paste(thumb.resize((cell_size, cell_size), Image.LANCZOS), (x, y))
+
+        # Number badge top-left
+        draw.rectangle([x, y, x + 28, y + 26], fill=(220, 100, 40))
+        draw.text((x + 5, y + 4), num_label, fill=(255, 255, 255), font=font_num)
+
+        # Filename label below
+        label_y = y + cell_size + 4
+        short = file_label if len(file_label) <= 36 else file_label[:33] + '...'
+        draw.text((x + 4, label_y), short, fill=(80, 70, 60), font=font)
+
+        # Border
+        draw.rectangle([x, y, x + cell_size, y + cell_size], outline=(200, 195, 185))
+
+    return grid
+
+
+def compare_photos(person_name, cell_size=280, cols=3):
+    """Process all staging images for comparison and open a grid."""
+    staging, _ = get_dirs()
+
+    if not staging.exists():
+        print(f"Staging folder not found: {staging}")
+        sys.exit(1)
+
+    images = [f for f in sorted(staging.iterdir()) if f.suffix.lower() in SUPPORTED_FORMATS]
+    if not images:
+        print("No images in staging folder.")
+        sys.exit(1)
+
+    print(f"Comparing {len(images)} candidate(s) for '{person_name}'...\n")
+
+    entries = []
+    for i, source in enumerate(images, 1):
+        try:
+            cropped = process_image(source)
+            enhanced = auto_enhance(cropped.copy())
+            entries.append((str(i), source.name, enhanced))
+            print(f"  {i}. {source.name}")
+        except Exception as e:
+            print(f"  Skipping {source.name}: {e}")
+
+    if not entries:
+        print("No images could be processed.")
+        sys.exit(1)
+
+    grid = make_comparison_grid(entries, cell_size=cell_size, cols=cols)
+    out_path = Path('/tmp') / f"compare-{person_name}.png"
+    grid.save(out_path)
+
+    print(f"\nGrid saved: {out_path}")
+    subprocess.run(['open', str(out_path)])
+
+    print(f"\nPick a number and run:")
+    for i, (_, fname, _) in enumerate(entries, 1):
+        print(f"  {i}. python process_photo.py {person_name} \"{fname}\" --force")
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Process personal photos for letter cards",
@@ -179,6 +273,15 @@ Examples:
     if args.list:
         list_staging()
         return 0
+
+    # Compare mode: python process_photo.py compare NAME
+    if args.name == 'compare':
+        if not args.source:
+            print("Usage: python process_photo.py compare <name>")
+            print("Example: python process_photo.py compare tata")
+            sys.exit(1)
+        compare_photos(args.source)
+        return
 
     # Need a name to process
     if not args.name:

--- a/process_photo.py
+++ b/process_photo.py
@@ -17,7 +17,6 @@ The output folder is:  ~/.lettercards/personal/
 
 import argparse
 import os
-import subprocess
 import sys
 from pathlib import Path
 from PIL import Image, ImageDraw, ImageEnhance, ImageFont, ImageOps
@@ -240,7 +239,8 @@ def compare_photos(person_name, cell_size=280, cols=3):
     grid.save(out_path)
 
     print(f"\nGrid saved: {out_path}")
-    subprocess.run(['open', str(out_path)])
+    import webbrowser
+    webbrowser.open(out_path.as_uri())
 
     print(f"\nPick a number and run:")
     for i, (_, fname, _) in enumerate(entries, 1):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -70,3 +70,89 @@ def test_decode_returns_pil_image():
     b64 = make_b64_image(300, 300)
     result = mcp_server.decode_and_process(b64)
     assert isinstance(result, Image.Image)
+
+
+# ── render_card ──────────────────────────────────────────────────────────────
+
+def make_photo(size=200):
+    return Image.new('RGB', (size, size), (180, 120, 60))
+
+
+def test_render_card_returns_image():
+    photo = make_photo()
+    card = mcp_server.render_card(photo, 'appel')
+    assert isinstance(card, Image.Image)
+
+
+def test_render_card_correct_dimensions():
+    photo = make_photo()
+    card = mcp_server.render_card(photo, 'deur')
+    assert card.size == (mcp_server.CARD_W, mcp_server.CARD_H)
+
+
+def test_render_card_uses_letter_color_for_known_letter():
+    """Card for letter 'a' uses the 'a' accent colour somewhere in the image."""
+    photo = make_photo()
+    card = mcp_server.render_card(photo, 'appel')
+    expected_color = mcp_server.LETTER_COLORS['a']
+    card_rgb = card.convert('RGB')
+    pixels = [card_rgb.getpixel((x, y)) for x in range(card_rgb.width) for y in range(card_rgb.height)]
+    assert any(p[:3] == expected_color for p in pixels)
+
+
+def test_render_card_unknown_letter_uses_default_color():
+    """Card for a word with no letter mapping falls back gracefully."""
+    photo = make_photo()
+    card = mcp_server.render_card(photo, '1ding')
+    assert card.size == (mcp_server.CARD_W, mcp_server.CARD_H)
+
+
+# ── save_photo ───────────────────────────────────────────────────────────────
+
+def test_save_photo_writes_file(tmp_path, monkeypatch):
+    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path))
+    import importlib
+    importlib.reload(mcp_server)
+
+    b64 = make_b64_image(300, 400)
+    mcp_server.save_photo(image_data=b64, name='tata')
+
+    out = tmp_path / 'tata.png'
+    assert out.exists()
+    img = Image.open(out)
+    assert img.format == 'PNG'
+
+
+def test_save_photo_lowercases_name(tmp_path, monkeypatch):
+    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path))
+    import importlib
+    importlib.reload(mcp_server)
+
+    b64 = make_b64_image(300, 300)
+    mcp_server.save_photo(image_data=b64, name='Mama')
+
+    assert (tmp_path / 'mama.png').exists()
+
+
+def test_save_photo_creates_personal_dir(tmp_path, monkeypatch):
+    personal_dir = tmp_path / 'new' / 'nested' / 'personal'
+    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(personal_dir))
+    import importlib
+    importlib.reload(mcp_server)
+
+    b64 = make_b64_image(300, 300)
+    mcp_server.save_photo(image_data=b64, name='opa')
+
+    assert (personal_dir / 'opa.png').exists()
+
+
+def test_save_photo_returns_string_with_path(tmp_path, monkeypatch):
+    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path))
+    import importlib
+    importlib.reload(mcp_server)
+
+    b64 = make_b64_image(300, 300)
+    result = mcp_server.save_photo(image_data=b64, name='oma')
+
+    assert 'oma.png' in result
+    assert isinstance(result, str)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -33,3 +33,40 @@ def test_personal_dir_default_when_env_not_set(monkeypatch):
     import importlib
     importlib.reload(mcp_server)
     assert mcp_server.PERSONAL_DIR == Path.home() / '.lettercards' / 'personal'
+
+
+# ── decode_and_process ───────────────────────────────────────────────────────
+
+def test_decode_portrait_crops_to_square():
+    """Portrait (tall) image: crop takes top square (width × width)."""
+    b64 = make_b64_image(300, 500)
+    result = mcp_server.decode_and_process(b64, size=100)
+    assert result.size == (100, 100)
+
+
+def test_decode_landscape_crops_center():
+    """Landscape (wide) image: crop takes centre square."""
+    b64 = make_b64_image(600, 300)
+    result = mcp_server.decode_and_process(b64, size=100)
+    assert result.size == (100, 100)
+
+
+def test_decode_square_unchanged_crop():
+    b64 = make_b64_image(400, 400)
+    result = mcp_server.decode_and_process(b64, size=100)
+    assert result.size == (100, 100)
+
+
+def test_decode_rgba_converted_to_rgb():
+    img = Image.new('RGBA', (300, 300), (100, 150, 200, 128))
+    buf = io.BytesIO()
+    img.save(buf, format='PNG')
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    result = mcp_server.decode_and_process(b64, size=100)
+    assert result.mode == 'RGB'
+
+
+def test_decode_returns_pil_image():
+    b64 = make_b64_image(300, 300)
+    result = mcp_server.decode_and_process(b64)
+    assert isinstance(result, Image.Image)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,35 @@
+"""Tests for mcp_server.py — image processing and MCP tool behaviour."""
+import base64
+import io
+import os
+import pytest
+from pathlib import Path
+from PIL import Image
+
+import mcp_server
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def make_b64_image(width=300, height=400, color=(200, 100, 50)):
+    """Return a base64-encoded JPEG of the given dimensions."""
+    img = Image.new('RGB', (width, height), color)
+    buf = io.BytesIO()
+    img.save(buf, format='JPEG')
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+# ── PERSONAL_DIR env var ─────────────────────────────────────────────────────
+
+def test_personal_dir_uses_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path / 'custom'))
+    import importlib
+    importlib.reload(mcp_server)
+    assert mcp_server.PERSONAL_DIR == tmp_path / 'custom'
+
+
+def test_personal_dir_default_when_env_not_set(monkeypatch):
+    monkeypatch.delenv('LETTERCARDS_PERSONAL_DIR', raising=False)
+    import importlib
+    importlib.reload(mcp_server)
+    assert mcp_server.PERSONAL_DIR == Path.home() / '.lettercards' / 'personal'

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -19,6 +19,13 @@ def make_b64_image(width=300, height=400, color=(200, 100, 50)):
     return base64.b64encode(buf.getvalue()).decode()
 
 
+def make_image_file(path, width=300, height=400, color=(200, 100, 50)):
+    """Write a JPEG image to path and return the path."""
+    img = Image.new('RGB', (width, height), color)
+    img.save(path, 'JPEG')
+    return path
+
+
 # ── PERSONAL_DIR env var ─────────────────────────────────────────────────────
 
 def test_personal_dir_uses_env_var(tmp_path, monkeypatch):
@@ -72,6 +79,26 @@ def test_decode_returns_pil_image():
     assert isinstance(result, Image.Image)
 
 
+# ── load_and_process ─────────────────────────────────────────────────────────
+
+def test_load_portrait_crops_to_square(tmp_path):
+    p = make_image_file(tmp_path / 'p.jpg', 300, 500)
+    result = mcp_server.load_and_process(str(p), size=100)
+    assert result.size == (100, 100)
+
+
+def test_load_landscape_crops_center(tmp_path):
+    p = make_image_file(tmp_path / 'l.jpg', 600, 300)
+    result = mcp_server.load_and_process(str(p), size=100)
+    assert result.size == (100, 100)
+
+
+def test_load_returns_pil_image(tmp_path):
+    p = make_image_file(tmp_path / 'sq.jpg', 300, 300)
+    result = mcp_server.load_and_process(str(p))
+    assert isinstance(result, Image.Image)
+
+
 # ── render_card ──────────────────────────────────────────────────────────────
 
 def make_photo(size=200):
@@ -107,31 +134,104 @@ def test_render_card_unknown_letter_uses_default_color():
     assert card.size == (mcp_server.CARD_W, mcp_server.CARD_H)
 
 
+# ── pick_photos (directory mode — no dialog needed) ──────────────────────────
+
+def test_pick_photos_directory_lists_images(tmp_path):
+    make_image_file(tmp_path / 'a.jpg')
+    make_image_file(tmp_path / 'b.png')
+    (tmp_path / 'notes.txt').write_text('ignore me')
+
+    result = mcp_server.pick_photos('test', directory=str(tmp_path))
+    assert '1.' in result
+    assert '2.' in result
+    assert 'notes.txt' not in result
+
+
+def test_pick_photos_directory_not_found():
+    result = mcp_server.pick_photos('test', directory='/nonexistent/definitely/not/here')
+    assert 'not found' in result.lower()
+
+
+def test_pick_photos_directory_empty(tmp_path):
+    result = mcp_server.pick_photos('test', directory=str(tmp_path))
+    assert 'No photos' in result
+
+
+def test_pick_photos_directory_returns_absolute_paths(tmp_path):
+    make_image_file(tmp_path / 'photo.jpg')
+    result = mcp_server.pick_photos('test', directory=str(tmp_path))
+    assert str(tmp_path) in result
+
+
+# ── generate_photo_grid ──────────────────────────────────────────────────────
+
+def test_generate_photo_grid_returns_mcp_image(tmp_path):
+    paths = []
+    for i in range(3):
+        p = tmp_path / f'photo{i}.jpg'
+        make_image_file(p, 300, 300, color=(50 * i, 80, 120))
+        paths.append(str(p))
+
+    from mcp.server.fastmcp import Image as MCPImage
+    result = mcp_server.generate_photo_grid(paths)
+    assert result is not None
+
+
+def test_generate_photo_grid_single_photo(tmp_path):
+    p = make_image_file(tmp_path / 'solo.jpg', 300, 300)
+    result = mcp_server.generate_photo_grid([str(p)])
+    assert result is not None
+
+
+def test_generate_photo_grid_bad_path_does_not_raise(tmp_path):
+    p = make_image_file(tmp_path / 'good.jpg', 300, 300)
+    result = mcp_server.generate_photo_grid([str(p), '/nonexistent/photo.jpg'])
+    assert result is not None
+
+
+# ── generate_comparison ───────────────────────────────────────────────────────
+
+def test_generate_comparison_returns_mcp_image(tmp_path):
+    paths = []
+    for i in range(2):
+        p = tmp_path / f'cand{i}.jpg'
+        make_image_file(p, 300, 400, color=(100 + 30 * i, 80, 60))
+        paths.append(str(p))
+
+    result = mcp_server.generate_comparison('Tata', paths)
+    assert result is not None
+
+
+def test_generate_comparison_single_photo(tmp_path):
+    p = make_image_file(tmp_path / 'one.jpg', 300, 400)
+    result = mcp_server.generate_comparison('mama', [str(p)])
+    assert result is not None
+
+
 # ── save_photo ───────────────────────────────────────────────────────────────
 
 def test_save_photo_writes_file(tmp_path, monkeypatch):
-    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path))
+    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path / 'personal'))
     import importlib
     importlib.reload(mcp_server)
 
-    b64 = make_b64_image(300, 400)
-    mcp_server.save_photo(image_data=b64, name='tata')
+    src = make_image_file(tmp_path / 'tata.jpg', 300, 400)
+    mcp_server.save_photo(name='tata', file_path=str(src))
 
-    out = tmp_path / 'tata.png'
+    out = tmp_path / 'personal' / 'tata.png'
     assert out.exists()
-    img = Image.open(out)
-    assert img.format == 'PNG'
+    assert Image.open(out).format == 'PNG'
 
 
 def test_save_photo_lowercases_name(tmp_path, monkeypatch):
-    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path))
+    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path / 'personal'))
     import importlib
     importlib.reload(mcp_server)
 
-    b64 = make_b64_image(300, 300)
-    mcp_server.save_photo(image_data=b64, name='Mama')
+    src = make_image_file(tmp_path / 'mama.jpg', 300, 300)
+    mcp_server.save_photo(name='Mama', file_path=str(src))
 
-    assert (tmp_path / 'mama.png').exists()
+    assert (tmp_path / 'personal' / 'mama.png').exists()
 
 
 def test_save_photo_creates_personal_dir(tmp_path, monkeypatch):
@@ -140,19 +240,19 @@ def test_save_photo_creates_personal_dir(tmp_path, monkeypatch):
     import importlib
     importlib.reload(mcp_server)
 
-    b64 = make_b64_image(300, 300)
-    mcp_server.save_photo(image_data=b64, name='opa')
+    src = make_image_file(tmp_path / 'opa.jpg', 300, 300)
+    mcp_server.save_photo(name='opa', file_path=str(src))
 
     assert (personal_dir / 'opa.png').exists()
 
 
 def test_save_photo_returns_string_with_path(tmp_path, monkeypatch):
-    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path))
+    monkeypatch.setenv('LETTERCARDS_PERSONAL_DIR', str(tmp_path / 'personal'))
     import importlib
     importlib.reload(mcp_server)
 
-    b64 = make_b64_image(300, 300)
-    result = mcp_server.save_photo(image_data=b64, name='oma')
+    src = make_image_file(tmp_path / 'oma.jpg', 300, 300)
+    result = mcp_server.save_photo(name='oma', file_path=str(src))
 
     assert 'oma.png' in result
     assert isinstance(result, str)

--- a/tests/test_process_photo.py
+++ b/tests/test_process_photo.py
@@ -99,3 +99,53 @@ def test_result_is_pil_image(tmp_path):
     path = make_image(tmp_path, 300, 400)
     result = process_image(path)
     assert isinstance(result, Image.Image)
+
+
+# ── auto_enhance ─────────────────────────────────────────────────────────────
+
+from process_photo import auto_enhance, make_comparison_grid
+
+
+def test_auto_enhance_returns_pil_image():
+    img = Image.new('RGB', (200, 200), (100, 100, 100))
+    result = auto_enhance(img)
+    assert isinstance(result, Image.Image)
+
+
+def test_auto_enhance_same_size():
+    img = Image.new('RGB', (200, 200), (100, 100, 100))
+    result = auto_enhance(img)
+    assert result.size == img.size
+
+
+def test_auto_enhance_returns_rgb():
+    img = Image.new('RGB', (200, 200), (100, 100, 100))
+    result = auto_enhance(img)
+    assert result.mode == 'RGB'
+
+
+# ── make_comparison_grid ─────────────────────────────────────────────────────
+
+def make_thumb(color=(200, 100, 50), size=100):
+    return Image.new('RGB', (size, size), color)
+
+
+def test_make_comparison_grid_single_entry():
+    entries = [('1', 'photo.jpg', make_thumb())]
+    grid = make_comparison_grid(entries, cell_size=100, cols=3)
+    assert isinstance(grid, Image.Image)
+
+
+def test_make_comparison_grid_multiple_entries_wraps_rows():
+    entries = [(str(i), f'photo{i}.jpg', make_thumb()) for i in range(4)]
+    grid = make_comparison_grid(entries, cell_size=100, cols=3)
+    assert isinstance(grid, Image.Image)
+    assert grid.height > 0
+
+
+def test_make_comparison_grid_truncates_long_filename():
+    """Filenames longer than 36 chars should not raise."""
+    long_name = 'a' * 40 + '.jpg'
+    entries = [('1', long_name, make_thumb())]
+    grid = make_comparison_grid(entries, cell_size=100, cols=1)
+    assert isinstance(grid, Image.Image)


### PR DESCRIPTION
## Summary

Redesigned MCP photo wizard based on end-to-end test feedback. Replaces the staging-folder / inline-drag approach with a native OS file picker that works on any platform and with any MCP-capable AI client (Claude Desktop, ChatGPT Desktop, etc.).

## What's in this PR

**`mcp_server.py`** — rewritten with four user-facing tools:
- `pick_photos(name, directory=None)` — opens a native OS file picker dialog (tkinter; macOS, Windows, Linux with display); falls back to directory listing in headless environments
- `generate_photo_grid(file_paths)` — numbered thumbnail grid of raw photos; the AI evaluates this with vision to pre-select the best 2–3 from a larger batch (used when 4+ photos are selected)
- `generate_comparison(name, file_paths)` — side-by-side grid of actual rendered lettercards for final comparison
- `save_photo(name, file_path)` — saves the chosen photo to `~/.lettercards/personal/`
- `list_staging_photos()` — demoted to fallback/power-user tool

**`docs/mcp-setup.md`** — rewritten: picker-based flow, cross-platform config paths (macOS/Windows/Linux), headless fallback, font troubleshooting.

**`process_photo.py`** — `compare` CLI mode now uses `webbrowser.open()` instead of `subprocess.run(['open', ...])` (cross-platform).

**`tests/test_mcp_server.py`** — updated and extended: `save_photo` tests use file paths; added tests for `load_and_process`, `pick_photos` (directory mode), `generate_photo_grid`, `generate_comparison`. **41 tests, all passing.**

## Flow

```
User: "make a card for Tata"
  → pick_photos("Tata")          file picker opens, user selects photos
  → [4+ photos] generate_photo_grid(all_paths)   AI evaluates with vision, picks best 2-3
  → generate_comparison("Tata", best_paths)       rendered lettercards side-by-side
  → User: "use number 2"
  → save_photo("Tata", chosen_path)
```

For 1–3 photos, `generate_photo_grid` is skipped and `generate_comparison` is called immediately.

## Why the previous approach was replaced

End-to-end testing (March 31) revealed two fundamental failures:
1. **Inline drag is broken by design** — when photos are dragged into Claude Desktop, the MCP server receives nothing. Claude can see them via vision but cannot pass them to MCP tools.
2. **Staging folder isn't natural** — users had to know to pre-copy photos there, and the comparison grid wasn't surfacing where expected.

The file picker bypasses both: photos come from anywhere on disk via a native dialog, and the AI gets real file paths to work with.

## Platform & AI agnosticism

- File picker: `tkinter.filedialog` (standard library, works on macOS/Windows/Linux)
- Fonts: try `fonts/` repo dir first, then system paths for macOS/Linux/Windows, PIL default fallback — no hardcoded `/System/Library/Fonts/`
- Server instructions contain no Claude Desktop-specific UI references — any vision-capable MCP client can follow the flow

## Known gaps (non-blocking for POC)

- File picker not yet tested on Windows / Linux desktop
- Inline drag flow removed — users who want to use photos from their phone camera roll need to transfer to disk first (or use the directory fallback)
- Path traversal in `file_path` / `name` parameters is not guarded — low risk for a local MCP server with a trusted model, tracked as follow-up

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)