### PR TITLE
Allow read-only gh commands without prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,14 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh api user *)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

- Adds `permissions.allow` to `.claude/settings.json` for six read-only `gh` commands
- `gh issue view/list`, `gh pr view/list/checks`, `gh api user` no longer prompt for approval
- Write/mutate operations (`gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr merge`) remain as prompts

## Why

These commands are used constantly during backlog grooming and reviews — the prompts add friction without security benefit since they're purely read operations against the authenticated user's own repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)