### PR TITLE
Phase 1b: introduce deck-state.json — printed card inventory, sessions, learning progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 .DS_Store
 venv/
 letterkaarten.pdf
+deck-state.json
 .tmp/

--- a/deck-state.example.json
+++ b/deck-state.example.json
@@ -1,0 +1,72 @@
+{
+  "deck_protocol": "1.0",
+  "next_batch": ["h", "k", "n"],
+  "printed_cards": [
+    {"word": "appel", "printed_date": "2026-03-20"},
+    {"word": "deur", "printed_date": "2026-03-20"},
+    {"word": "eend", "printed_date": "2026-03-20"},
+    {"word": "oma", "printed_date": "2026-03-20"}
+  ],
+  "sessions": [
+    {
+      "date": "2026-03-18",
+      "type": "generation",
+      "summary": "Added words: appel, aap, auto for letter A",
+      "cards_added": ["appel", "aap", "auto"],
+      "cards_modified": []
+    },
+    {
+      "date": "2026-03-20",
+      "type": "print",
+      "letters": ["a", "d", "e", "o"],
+      "card_count": 12,
+      "notes": "Printed on 160gsm, laminated"
+    },
+    {
+      "date": "2026-03-22",
+      "type": "review",
+      "duration_minutes": 15,
+      "letters_played": ["a", "d", "o"],
+      "observations": [
+        {
+          "card": "appel",
+          "reaction": "positive",
+          "notes": "Points and says 'appel!' immediately"
+        },
+        {
+          "card": "wolf",
+          "reaction": "confused",
+          "notes": "Says 'hond' instead"
+        }
+      ]
+    }
+  ],
+  "progress": {
+    "letters": {
+      "a": {
+        "status": "recognized",
+        "first_introduced": "2026-03-20",
+        "observations": [
+          {"date": "2026-03-22", "note": "Points at A on cereal box"}
+        ]
+      },
+      "d": {
+        "status": "learning",
+        "first_introduced": "2026-03-20",
+        "observations": [
+          {"date": "2026-03-22", "note": "Knows 'deur' but doesn't connect to letter yet"}
+        ]
+      }
+    },
+    "summary_snapshots": [
+      {
+        "date": "2026-03-25",
+        "total_letters_introduced": 6,
+        "recognized": ["a", "o"],
+        "learning": ["d", "e"],
+        "not_yet": ["w", "z"],
+        "notes": "Good progress on vowels"
+      }
+    ]
+  }
+}

--- a/deck_state.py
+++ b/deck_state.py
@@ -1,0 +1,72 @@
+"""
+deck_state.py — load and validate deck-state.json.
+
+The deck state file is machine-managed operational memory. It lives alongside
+deck.csv (default: ~/.lettercards/) and tracks printed cards, sessions, and
+learning progress. It is NOT checked into the engine repo.
+
+Usage:
+    from deck_state import load_deck_state, validate_deck_state
+
+    state = load_deck_state(path)          # Returns dict or None
+    warnings = validate_deck_state(state, csv_words)  # Returns list of strings
+"""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+SUPPORTED_PROTOCOL = "1.0"
+
+
+def load_deck_state(path: Path) -> Optional[dict]:
+    """
+    Load deck-state.json from path.
+
+    Returns the parsed dict, or None if the file does not exist or cannot be parsed.
+    Never raises — a missing or corrupt deck-state.json is handled gracefully.
+    """
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def validate_deck_state(state: dict, csv_words: set) -> list:
+    """
+    Validate deck state against the current deck.csv word list.
+
+    Args:
+        state: Parsed deck-state.json dict.
+        csv_words: Set of word strings from cards.csv (all active words).
+
+    Returns:
+        List of warning strings. Empty list means no issues found.
+    """
+    warnings = []
+
+    # Check deck_protocol presence and version
+    protocol = state.get("deck_protocol")
+    if protocol is None:
+        warnings.append(
+            "deck-state.json is missing 'deck_protocol' field. "
+            f"Expected \"{SUPPORTED_PROTOCOL}\". File may be from an older version."
+        )
+    elif protocol != SUPPORTED_PROTOCOL:
+        warnings.append(
+            f"deck-state.json has deck_protocol \"{protocol}\" but this engine supports "
+            f"\"{SUPPORTED_PROTOCOL}\". Some features may not work correctly."
+        )
+
+    # Check that all printed_cards words exist in deck.csv
+    for entry in state.get("printed_cards", []):
+        word = entry.get("word", "")
+        if word and word not in csv_words:
+            warnings.append(
+                f"printed_cards contains '{word}' which is not in cards.csv. "
+                "The card may have been removed or renamed."
+            )
+
+    return warnings

--- a/deck_state.py
+++ b/deck_state.py
@@ -34,17 +34,19 @@ def load_deck_state(path: Path) -> Optional[dict]:
         return None
 
 
-def validate_deck_state(state: dict, csv_words: set) -> list:
+def validate_deck_state(state: Optional[dict], csv_words: set) -> list:
     """
     Validate deck state against the current deck.csv word list.
 
     Args:
-        state: Parsed deck-state.json dict.
+        state: Parsed deck-state.json dict, or None if the file was missing/corrupt.
         csv_words: Set of word strings from cards.csv (all active words).
 
     Returns:
         List of warning strings. Empty list means no issues found.
     """
+    if state is None:
+        return []
     warnings = []
 
     # Check deck_protocol presence and version
@@ -61,12 +63,18 @@ def validate_deck_state(state: dict, csv_words: set) -> list:
         )
 
     # Check that all printed_cards words exist in deck.csv
-    for entry in state.get("printed_cards", []):
-        word = entry.get("word", "")
-        if word and word not in csv_words:
-            warnings.append(
-                f"printed_cards contains '{word}' which is not in cards.csv. "
-                "The card may have been removed or renamed."
-            )
+    printed_cards = state.get("printed_cards", [])
+    if not isinstance(printed_cards, list):
+        warnings.append(
+            "deck-state.json 'printed_cards' is not a list — file may be corrupt."
+        )
+    else:
+        for entry in printed_cards:
+            word = entry.get("word", "")
+            if word and word not in csv_words:
+                warnings.append(
+                    f"printed_cards contains '{word}' which is not in cards.csv. "
+                    "The card may have been removed or renamed."
+                )
 
     return warnings

--- a/deck_state.py
+++ b/deck_state.py
@@ -4,43 +4,49 @@ deck_state.py — load and validate deck-state.json.
 The deck state file is machine-managed operational memory. It lives alongside
 deck.csv (default: ~/.lettercards/) and tracks printed cards, sessions, and
 learning progress. It is NOT checked into the engine repo.
-
-Usage:
-    from deck_state import load_deck_state, validate_deck_state
-
-    state = load_deck_state(path)          # Returns dict or None
-    warnings = validate_deck_state(state, csv_words)  # Returns list of strings
 """
+
+from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Optional
 
 SUPPORTED_PROTOCOL = "1.0"
 
 
-def load_deck_state(path: Path) -> Optional[dict]:
+def read_deck_state(path: Path) -> tuple[dict | None, str | None]:
     """
-    Load deck-state.json from path.
+    Read deck-state.json from path.
 
-    Returns the parsed dict, or None if the file does not exist or cannot be parsed.
-    Never raises — a missing or corrupt deck-state.json is handled gracefully.
+    Returns:
+        (state, error_message)
+        - missing file -> (None, None)
+        - valid file -> (dict, None)
+        - invalid file -> (None, <message>)
     """
     try:
-        return json.loads(Path(path).read_text(encoding="utf-8"))
+        return json.loads(Path(path).read_text(encoding="utf-8")), None
     except FileNotFoundError:
-        return None
-    except (json.JSONDecodeError, OSError):
-        return None
+        return None, None
+    except json.JSONDecodeError as exc:
+        return None, f"could not parse JSON: {exc.msg}"
+    except OSError:
+        return None, "could not read file"
 
 
-def validate_deck_state(state: Optional[dict], csv_words: set) -> list:
+def load_deck_state(path: Path) -> dict | None:
+    """Load deck-state.json, returning None when the file is missing or invalid."""
+    state, _error = read_deck_state(path)
+    return state
+
+
+def validate_deck_state(state: dict | None, csv_words: set[str]) -> list[str]:
     """
     Validate deck state against the current deck.csv word list.
 
     Args:
         state: Parsed deck-state.json dict, or None if the file was missing/corrupt.
-        csv_words: Set of word strings from cards.csv (all active words).
+        csv_words: Set of word strings from the selected deck CSV.
 
     Returns:
         List of warning strings. Empty list means no issues found.
@@ -69,9 +75,21 @@ def validate_deck_state(state: Optional[dict], csv_words: set) -> list:
             "deck-state.json 'printed_cards' is not a list — file may be corrupt."
         )
     else:
-        for entry in printed_cards:
+        for index, entry in enumerate(printed_cards):
+            if not isinstance(entry, dict):
+                warnings.append(
+                    f"printed_cards[{index}] is malformed — expected an object."
+                )
+                continue
+
             word = entry.get("word", "")
-            if word and word not in csv_words:
+            if not isinstance(word, str) or not word.strip():
+                warnings.append(
+                    f"printed_cards[{index}] is missing a valid 'word' field."
+                )
+                continue
+
+            if word not in csv_words:
                 warnings.append(
                     f"printed_cards contains '{word}' which is not in cards.csv. "
                     "The card may have been removed or renamed."

--- a/docs/superpowers/plans/2026-03-29-phase-1b-deck-state.md
+++ b/docs/superpowers/plans/2026-03-29-phase-1b-deck-state.md
@@ -1,0 +1,710 @@
+# Phase 1b: deck-state.json Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce `deck-state.json` as machine-managed operational memory — tracking printed cards, sessions, and learning progress — and wire it into the generate.py startup validation and `--status` command.
+
+**Architecture:** A new `deck_state.py` module handles all loading and validation of `deck-state.json`, keeping that logic out of `generate.py`. The `generate.py` main() function calls this module on startup to print warnings, and exposes a `--status` flag that prints a human-readable summary. The file is added to `.gitignore` because it belongs to the user deck, not the engine repo.
+
+**Tech Stack:** Python 3.10+, stdlib only (`json`, `pathlib`). No new dependencies. Tests use `pytest` with `tmp_path` fixture. Run tests via `venv/bin/pytest tests/`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `deck_state.py` | Create | Load and validate `deck-state.json`; return structured data and warnings |
+| `deck-state.example.json` | Create | Schema reference / documentation artifact |
+| `generate.py` | Modify | Add `--status` flag; call validation on startup; import from `deck_state` |
+| `.gitignore` | Modify | Add `deck-state.json` |
+| `tests/test_deck_state.py` | Create | All tests for `deck_state.py` and generate.py integration |
+
+---
+
+## Task 1: deck_state.py — load and validate
+
+**Files:**
+- Create: `deck_state.py`
+- Create: `tests/test_deck_state.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_deck_state.py`:
+
+```python
+"""Tests for deck_state.py — load and validate deck-state.json."""
+import json
+import pytest
+from pathlib import Path
+
+from deck_state import load_deck_state, validate_deck_state
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def write_state(tmp_path, data):
+    p = tmp_path / "deck-state.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+# ── load_deck_state ───────────────────────────────────────────────────────────
+
+def test_load_deck_state_returns_dict_for_valid_file(tmp_path):
+    p = write_state(tmp_path, {"deck_protocol": "1.0", "printed_cards": []})
+    result = load_deck_state(p)
+    assert isinstance(result, dict)
+    assert result["deck_protocol"] == "1.0"
+
+
+def test_load_deck_state_returns_none_when_file_missing(tmp_path):
+    result = load_deck_state(tmp_path / "nonexistent.json")
+    assert result is None
+
+
+def test_load_deck_state_returns_none_for_invalid_json(tmp_path):
+    p = tmp_path / "deck-state.json"
+    p.write_text("not valid json {{{")
+    result = load_deck_state(p)
+    assert result is None
+
+
+# ── validate_deck_state ───────────────────────────────────────────────────────
+
+def test_validate_no_warnings_for_valid_state(tmp_path):
+    state = {
+        "deck_protocol": "1.0",
+        "printed_cards": [{"word": "appel"}, {"word": "deur"}],
+    }
+    csv_words = {"appel", "deur", "eend"}
+    warnings = validate_deck_state(state, csv_words)
+    assert warnings == []
+
+
+def test_validate_warns_when_deck_protocol_missing():
+    state = {"printed_cards": []}
+    warnings = validate_deck_state(state, set())
+    assert any("deck_protocol" in w for w in warnings)
+
+
+def test_validate_warns_when_deck_protocol_version_mismatch():
+    state = {"deck_protocol": "99.0", "printed_cards": []}
+    warnings = validate_deck_state(state, set())
+    assert any("99.0" in w for w in warnings)
+
+
+def test_validate_no_warning_for_supported_protocol():
+    state = {"deck_protocol": "1.0", "printed_cards": []}
+    warnings = validate_deck_state(state, set())
+    assert not any("deck_protocol" in w for w in warnings)
+
+
+def test_validate_warns_for_printed_card_not_in_csv():
+    state = {
+        "deck_protocol": "1.0",
+        "printed_cards": [{"word": "wolf"}],
+    }
+    csv_words = {"appel", "deur"}
+    warnings = validate_deck_state(state, csv_words)
+    assert any("wolf" in w for w in warnings)
+
+
+def test_validate_no_warning_when_printed_cards_empty():
+    state = {"deck_protocol": "1.0", "printed_cards": []}
+    warnings = validate_deck_state(state, {"appel"})
+    assert warnings == []
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+venv/bin/pytest tests/test_deck_state.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'deck_state'`
+
+- [ ] **Step 3: Create deck_state.py**
+
+```python
+"""
+deck_state.py — load and validate deck-state.json.
+
+The deck state file is machine-managed operational memory. It lives alongside
+deck.csv (default: ~/.lettercards/) and tracks printed cards, sessions, and
+learning progress. It is NOT checked into the engine repo.
+
+Usage:
+    from deck_state import load_deck_state, validate_deck_state
+
+    state = load_deck_state(path)          # Returns dict or None
+    warnings = validate_deck_state(state, csv_words)  # Returns list of strings
+"""
+
+import json
+from pathlib import Path
+
+SUPPORTED_PROTOCOL = "1.0"
+
+
+def load_deck_state(path: Path) -> dict | None:
+    """
+    Load deck-state.json from path.
+
+    Returns the parsed dict, or None if the file does not exist or cannot be parsed.
+    Never raises — a missing or corrupt deck-state.json is handled gracefully.
+    """
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def validate_deck_state(state: dict, csv_words: set) -> list:
+    """
+    Validate deck state against the current deck.csv word list.
+
+    Args:
+        state: Parsed deck-state.json dict.
+        csv_words: Set of word strings from cards.csv (all active words).
+
+    Returns:
+        List of warning strings. Empty list means no issues found.
+    """
+    warnings = []
+
+    # Check deck_protocol presence and version
+    protocol = state.get("deck_protocol")
+    if protocol is None:
+        warnings.append(
+            "deck-state.json is missing 'deck_protocol' field. "
+            f"Expected \"{SUPPORTED_PROTOCOL}\". File may be from an older version."
+        )
+    elif protocol != SUPPORTED_PROTOCOL:
+        warnings.append(
+            f"deck-state.json has deck_protocol \"{protocol}\" but this engine supports "
+            f"\"{SUPPORTED_PROTOCOL}\". Some features may not work correctly."
+        )
+
+    # Check that all printed_cards words exist in deck.csv
+    for entry in state.get("printed_cards", []):
+        word = entry.get("word", "")
+        if word and word not in csv_words:
+            warnings.append(
+                f"printed_cards contains '{word}' which is not in cards.csv. "
+                "The card may have been removed or renamed."
+            )
+
+    return warnings
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+venv/bin/pytest tests/test_deck_state.py -v
+```
+
+Expected: All 10 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deck_state.py tests/test_deck_state.py
+git commit -m "feat: add deck_state module — load and validate deck-state.json (#101)"
+```
+
+---
+
+## Task 2: deck-state.example.json and .gitignore
+
+**Files:**
+- Create: `deck-state.example.json`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Create deck-state.example.json**
+
+This file documents the schema and ships as a reference. It is NOT the actual user file.
+
+```json
+{
+  "deck_protocol": "1.0",
+  "next_batch": ["h", "k", "n"],
+  "printed_cards": [
+    {"word": "appel", "printed_date": "2026-03-20"},
+    {"word": "deur", "printed_date": "2026-03-20"},
+    {"word": "eend", "printed_date": "2026-03-20"},
+    {"word": "oma", "printed_date": "2026-03-20"}
+  ],
+  "sessions": [
+    {
+      "date": "2026-03-18",
+      "type": "generation",
+      "summary": "Added words: appel, aap, auto for letter A",
+      "cards_added": ["appel", "aap", "auto"],
+      "cards_modified": []
+    },
+    {
+      "date": "2026-03-20",
+      "type": "print",
+      "letters": ["a", "d", "e", "o"],
+      "card_count": 12,
+      "notes": "Printed on 160gsm, laminated"
+    },
+    {
+      "date": "2026-03-22",
+      "type": "review",
+      "duration_minutes": 15,
+      "letters_played": ["a", "d", "o"],
+      "observations": [
+        {
+          "card": "appel",
+          "reaction": "positive",
+          "notes": "Points and says 'appel!' immediately"
+        },
+        {
+          "card": "wolf",
+          "reaction": "confused",
+          "notes": "Says 'hond' instead"
+        }
+      ]
+    }
+  ],
+  "progress": {
+    "letters": {
+      "a": {
+        "status": "recognized",
+        "first_introduced": "2026-03-20",
+        "observations": [
+          {"date": "2026-03-22", "note": "Points at A on cereal box"}
+        ]
+      },
+      "d": {
+        "status": "learning",
+        "first_introduced": "2026-03-20",
+        "observations": [
+          {"date": "2026-03-22", "note": "Knows 'deur' but doesn't connect to letter yet"}
+        ]
+      }
+    },
+    "summary_snapshots": [
+      {
+        "date": "2026-03-25",
+        "total_letters_introduced": 6,
+        "recognized": ["a", "o"],
+        "learning": ["d", "e"],
+        "not_yet": ["w", "z"],
+        "notes": "Good progress on vowels"
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Add deck-state.json to .gitignore**
+
+Current `.gitignore` contents:
+```
+*.pyc
+__pycache__/
+.DS_Store
+venv/
+letterkaarten.pdf
+.tmp/
+```
+
+Add this line after `letterkaarten.pdf`:
+```
+deck-state.json
+```
+
+Final `.gitignore`:
+```
+*.pyc
+__pycache__/
+.DS_Store
+venv/
+letterkaarten.pdf
+deck-state.json
+.tmp/
+```
+
+- [ ] **Step 3: Verify deck-state.json is ignored**
+
+```bash
+echo '{}' > deck-state.json
+git status
+```
+
+Expected: `deck-state.json` does NOT appear in git status output (it's ignored).
+
+```bash
+rm deck-state.json
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deck-state.example.json .gitignore
+git commit -m "chore: add deck-state.example.json schema reference and gitignore entry (#101)"
+```
+
+---
+
+## Task 3: generate.py integration — startup validation and --status
+
+**Files:**
+- Modify: `generate.py`
+- Modify: `tests/test_deck_state.py` (add integration tests)
+
+The `--status` flag prints a deck summary and exits without generating a PDF.
+On every normal run, if `deck-state.json` exists, validate it and print any warnings.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `tests/test_deck_state.py`:
+
+```python
+# ── generate.py integration ───────────────────────────────────────────────────
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def write_csv_for_status(tmp_path, rows="a,appel,appel.png,,no\nd,deur,deur.png,,no\n"):
+    csv_file = tmp_path / "cards.csv"
+    csv_file.write_text("letter,word,image,font,personal\n" + rows)
+    return csv_file
+
+
+def test_status_flag_prints_summary(tmp_path):
+    write_csv_for_status(tmp_path)
+    state = {
+        "deck_protocol": "1.0",
+        "printed_cards": [{"word": "appel", "printed_date": "2026-03-20"}],
+        "sessions": [],
+    }
+    (tmp_path / "deck-state.json").write_text(json.dumps(state))
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--status", "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(tmp_path / "deck-state.json")],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "appel" in result.stdout
+    assert "printed" in result.stdout.lower()
+
+
+def test_status_flag_works_without_deck_state_file(tmp_path):
+    write_csv_for_status(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--status", "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(tmp_path / "nonexistent.json")],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "no deck-state" in result.stdout.lower() or "not found" in result.stdout.lower()
+
+
+def test_startup_validation_prints_warning_for_unknown_protocol(tmp_path):
+    write_csv_for_status(tmp_path)
+    state = {"deck_protocol": "99.0", "printed_cards": []}
+    (tmp_path / "deck-state.json").write_text(json.dumps(state))
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--no-placeholders",
+         "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(tmp_path / "deck-state.json"),
+         "--output", str(tmp_path / "out.pdf")],
+        capture_output=True, text=True
+    )
+    assert "99.0" in result.stdout or "99.0" in result.stderr
+
+
+def test_startup_validation_no_warning_when_state_missing(tmp_path):
+    write_csv_for_status(tmp_path)
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--no-placeholders",
+         "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(tmp_path / "nonexistent.json"),
+         "--output", str(tmp_path / "out.pdf")],
+        capture_output=True, text=True
+    )
+    # Should complete without errors or protocol warnings
+    assert "deck_protocol" not in result.stdout
+    assert "deck_protocol" not in result.stderr
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+venv/bin/pytest tests/test_deck_state.py::test_status_flag_prints_summary -v
+```
+
+Expected: FAIL — `generate.py` doesn't accept `--deck-state` or `--status` yet.
+
+- [ ] **Step 3: Modify generate.py**
+
+Add the import at the top of the imports block (after `from PIL import Image`):
+
+```python
+from deck_state import load_deck_state, validate_deck_state
+```
+
+Add two new argparse arguments inside `main()`, after the `--safe-letters-only` argument:
+
+```python
+    parser.add_argument('--status', action='store_true',
+                        help='Show deck status summary and exit (no PDF generated)')
+    parser.add_argument('--deck-state', type=str, default=None,
+                        help='Path to deck-state.json (default: deck-state.json next to cards.csv)')
+```
+
+Add the deck state path resolution after `personal_dir = get_personal_images_dir(args.personal_dir)`:
+
+```python
+    # Resolve deck state path
+    deck_state_path = Path(args.deck_state) if args.deck_state else csv_path.parent / 'deck-state.json'
+```
+
+Add `--status` handling after `deck_state_path` resolution, before the font registration block:
+
+```python
+    # --status: print deck summary and exit
+    if args.status:
+        state = load_deck_state(deck_state_path)
+        if state is None:
+            print(f"No deck-state.json found at {deck_state_path}")
+            print("Run some print sessions to start tracking your deck.")
+        else:
+            cards = load_cards(csv_path)
+            csv_words = {c['word'] for c in cards}
+            warnings = validate_deck_state(state, csv_words)
+            if warnings:
+                print("Warnings:")
+                for w in warnings:
+                    print(f"  ⚠ {w}")
+                print()
+            printed = state.get('printed_cards', [])
+            active_words = csv_words
+            not_printed = active_words - {e.get('word') for e in printed}
+            print(f"Active cards in deck.csv: {len(active_words)}")
+            print(f"Printed cards in inventory: {len(printed)}")
+            if not_printed:
+                print(f"Not yet printed ({len(not_printed)}): {', '.join(sorted(not_printed))}")
+            else:
+                print("All active cards have been printed.")
+            sessions = state.get('sessions', [])
+            print(f"Recorded sessions: {len(sessions)}")
+            next_batch = state.get('next_batch', [])
+            if next_batch:
+                print(f"Next planned batch: {', '.join(next_batch)}")
+        sys.exit(0)
+```
+
+Add startup validation after the `--status` block (still inside `main()`, before font registration):
+
+```python
+    # Startup validation: warn about deck state issues, but don't abort
+    state = load_deck_state(deck_state_path)
+    if state is not None:
+        cards_for_validation = load_cards(csv_path)
+        csv_words = {c['word'] for c in cards_for_validation}
+        warnings = validate_deck_state(state, csv_words)
+        for w in warnings:
+            print(f"⚠ deck-state warning: {w}")
+```
+
+The final `main()` function should look like this (complete replacement from line 497):
+
+```python
+def main():
+    parser = argparse.ArgumentParser(description="Generate letter learning cards as PDF")
+    parser.add_argument('--letters', type=str, default=None,
+                        help='Comma-separated letters to include (e.g., a,d,o)')
+    parser.add_argument('--font', type=str, default=None,
+                        help='Override font for all cards')
+    parser.add_argument('--output', type=str, default='letterkaarten.pdf',
+                        help='Output PDF filename')
+    parser.add_argument('--no-placeholders', action='store_true',
+                        help='Skip generating placeholder images')
+    parser.add_argument('--csv', type=str, default='cards.csv',
+                        help='Path to the CSV config file')
+    parser.add_argument('--personal-dir', type=str, default=None,
+                        help='Directory for personal photos (default: ~/.lettercards/personal/)')
+    parser.add_argument('--safe-letters-only', action='store_true',
+                        help='Exclude any letter that has at least one personal=yes card (useful for screenshots)')
+    parser.add_argument('--status', action='store_true',
+                        help='Show deck status summary and exit (no PDF generated)')
+    parser.add_argument('--deck-state', type=str, default=None,
+                        help='Path to deck-state.json (default: deck-state.json next to cards.csv)')
+    args = parser.parse_args()
+
+    base_dir = Path(__file__).parent
+    csv_path = base_dir / args.csv
+    images_dir = base_dir / "images"
+    personal_dir = get_personal_images_dir(args.personal_dir)
+    output_path = base_dir / args.output
+
+    # Resolve deck state path
+    deck_state_path = Path(args.deck_state) if args.deck_state else csv_path.parent / 'deck-state.json'
+
+    # --status: print deck summary and exit
+    if args.status:
+        state = load_deck_state(deck_state_path)
+        if state is None:
+            print(f"No deck-state.json found at {deck_state_path}")
+            print("Run some print sessions to start tracking your deck.")
+        else:
+            cards = load_cards(csv_path)
+            csv_words = {c['word'] for c in cards}
+            warnings = validate_deck_state(state, csv_words)
+            if warnings:
+                print("Warnings:")
+                for w in warnings:
+                    print(f"  ⚠ {w}")
+                print()
+            printed = state.get('printed_cards', [])
+            active_words = csv_words
+            not_printed = active_words - {e.get('word') for e in printed}
+            print(f"Active cards in deck.csv: {len(active_words)}")
+            print(f"Printed cards in inventory: {len(printed)}")
+            if not_printed:
+                print(f"Not yet printed ({len(not_printed)}): {', '.join(sorted(not_printed))}")
+            else:
+                print("All active cards have been printed.")
+            sessions = state.get('sessions', [])
+            print(f"Recorded sessions: {len(sessions)}")
+            next_batch = state.get('next_batch', [])
+            if next_batch:
+                print(f"Next planned batch: {', '.join(next_batch)}")
+        sys.exit(0)
+
+    # Startup validation: warn about deck state issues, but don't abort
+    state = load_deck_state(deck_state_path)
+    if state is not None:
+        cards_for_validation = load_cards(csv_path)
+        csv_words = {c['word'] for c in cards_for_validation}
+        warnings = validate_deck_state(state, csv_words)
+        for w in warnings:
+            print(f"⚠ deck-state warning: {w}")
+
+    # Register fonts
+    available_fonts = register_fonts()
+    print(f"Available fonts: {', '.join(available_fonts) or 'Helvetica (built-in)'}")
+
+    # Parse letter filter
+    letters_filter = None
+    if args.safe_letters_only:
+        safe = get_safe_letters(csv_path)
+        letters_filter = sorted(safe)
+        print(f"Safe letters (no personal=yes entries): {', '.join(letters_filter)}")
+    elif args.letters:
+        letters_filter = [l.strip().lower() for l in args.letters.split(',')]
+        print(f"Filtering letters: {', '.join(letters_filter)}")
+
+    # Load cards
+    cards = load_cards(csv_path, letters_filter)
+    if not cards:
+        print("No cards found! Check your CSV file.")
+        sys.exit(1)
+
+    print(f"Loaded {len(cards)} card entries")
+
+    # Generate placeholder images
+    if not args.no_placeholders:
+        print("\nGenerating placeholder images...")
+        generate_placeholder_images(cards, images_dir)
+
+    # Generate PDF
+    print(f"\nPersonal images dir: {personal_dir}")
+    print("Generating PDF...")
+    generate_pdf(cards, output_path, images_dir, personal_dir, available_fonts, args.font)
+
+
+if __name__ == '__main__':
+    main()
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+venv/bin/pytest tests/test_deck_state.py -v
+```
+
+Expected: All 14 tests pass.
+
+Also run the full test suite to verify nothing is broken:
+
+```bash
+venv/bin/pytest tests/ -v
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+python generate.py --status
+```
+
+Expected output (when no `deck-state.json` exists in repo root):
+```
+No deck-state.json found at /path/to/lettercards/deck-state.json
+Run some print sessions to start tracking your deck.
+```
+
+```bash
+cp deck-state.example.json deck-state.json
+python generate.py --status
+```
+
+Expected: Shows counts of active cards, printed cards, sessions, and next batch.
+
+```bash
+rm deck-state.json
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add generate.py tests/test_deck_state.py
+git commit -m "feat: add --status flag and startup validation to generate.py (#101)"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Acceptance criterion | Task |
+|---------------------|------|
+| `deck-state.json` schema defined | Task 2 (`deck-state.example.json`) |
+| Engine validates `deck_protocol` version on startup; warns if missing | Task 3 (startup validation in `generate.py`) |
+| Engine validates `printed_cards` words exist in `deck.csv` | Task 1 (`validate_deck_state`) + Task 3 |
+| `lettercards status` (or equivalent) prints a summary | Task 3 (`--status` flag) |
+| File in `.gitignore` | Task 2 |
+| Tests: valid file, missing file (graceful), mismatched protocol version | Task 1 + Task 3 |
+
+All criteria covered.
+
+### Placeholder scan
+
+No TBD, TODO, or vague placeholders found.
+
+### Type consistency
+
+- `load_deck_state(path: Path) -> dict | None` — used identically in Task 1 and Task 3
+- `validate_deck_state(state: dict, csv_words: set) -> list` — used identically in Task 1 and Task 3
+- `deck_state_path` — Path object in all uses
+- `csv_words` — set of strings in all uses

--- a/generate.py
+++ b/generate.py
@@ -533,7 +533,11 @@ def main():
             print(f"No deck-state.json found at {deck_state_path}")
             print("Run some print sessions to start tracking your deck.")
         else:
-            cards = load_cards(csv_path)
+            try:
+                cards = load_cards(csv_path)
+            except FileNotFoundError:
+                print(f"Error: CSV file not found: {csv_path}")
+                sys.exit(1)
             csv_words = {c['word'] for c in cards}
             warnings = validate_deck_state(state, csv_words)
             if warnings:
@@ -542,7 +546,7 @@ def main():
                     print(f"  ⚠ {w}")
                 print()
             printed = state.get('printed_cards', [])
-            printed_words = {e.get('word') for e in printed}
+            printed_words = {e.get('word') for e in printed if e.get('word')}
             not_printed = csv_words - printed_words
             print(f"Active cards in deck.csv: {len(csv_words)}")
             print(f"Printed cards in inventory: {len(printed)}")

--- a/generate.py
+++ b/generate.py
@@ -34,7 +34,7 @@ from reportlab.pdfgen import canvas
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from PIL import Image
-from deck_state import load_deck_state, validate_deck_state
+from deck_state import load_deck_state, read_deck_state, validate_deck_state
 
 # ── Config ──────────────────────────────────────────────────────────
 
@@ -423,6 +423,22 @@ def load_cards(csv_path, letters_filter=None):
     return cards
 
 
+def load_all_deck_words(csv_path):
+    """Load all words from the selected deck CSV, regardless of status or printability."""
+    words = set()
+    with open(csv_path, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            letter = row.get('letter', '').strip()
+            if not letter or letter.startswith('#'):
+                continue
+            word = row.get('word', '').strip()
+            if not word or 'geen voorbeeld' in word:
+                continue
+            words.add(word)
+    return words
+
+
 def get_image_path(card, images_dir, personal_dir):
     """Get the image path for a card, checking personal dir first for personal photos."""
     if not card['image']:
@@ -495,6 +511,62 @@ def generate_pdf(cards, output_path, images_dir, personal_dir, available_fonts, 
     print(f"  Pages: {(total + COLS * ROWS - 1) // (COLS * ROWS)}")
 
 
+def print_deck_status(csv_path, deck_state_path):
+    """Print a human-readable deck summary."""
+    try:
+        cards = load_cards(csv_path)
+        csv_words = load_all_deck_words(csv_path)
+    except FileNotFoundError:
+        print(f"Error: deck CSV not found: {csv_path}")
+        return 1
+
+    state, state_error = read_deck_state(deck_state_path)
+    if state_error:
+        print(f"Error: could not read deck-state.json at {deck_state_path}: {state_error}")
+        return 1
+    if state is None:
+        print(f"No deck-state.json found at {deck_state_path}")
+        print("Run some print or review sessions to start tracking deck state.")
+        return 0
+
+    warnings = validate_deck_state(state, csv_words)
+    if warnings:
+        print("Warnings:")
+        for warning in warnings:
+            print(f"  ⚠ {warning}")
+        print()
+
+    printed_cards = state.get("printed_cards", [])
+    printed_word_entries = [
+        entry.get("word")
+        for entry in printed_cards
+        if isinstance(entry, dict) and isinstance(entry.get("word"), str) and entry.get("word").strip()
+    ]
+    printed_word_set = set(printed_word_entries)
+    not_printed = sorted(csv_words - printed_word_set)
+
+    print(f"Active cards in selected deck: {len(cards)}")
+    print(f"Printed cards in inventory: {len(printed_cards)}")
+    if printed_word_entries:
+        print(f"Distinct printed words: {len(printed_word_set)}")
+    if not_printed:
+        print(f"Not yet printed ({len(not_printed)}): {', '.join(not_printed)}")
+    else:
+        print("All active cards have been printed at least once.")
+
+    sessions = state.get("sessions", [])
+    if isinstance(sessions, list):
+        print(f"Recorded sessions: {len(sessions)}")
+    else:
+        print("Recorded sessions: invalid data")
+
+    next_batch = state.get("next_batch", [])
+    if isinstance(next_batch, list) and next_batch:
+        print(f"Next planned batch: {', '.join(str(item) for item in next_batch)}")
+
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate letter learning cards as PDF")
     parser.add_argument('--letters', type=str, default=None,
@@ -514,7 +586,7 @@ def main():
     parser.add_argument('--status', action='store_true',
                         help='Show deck status summary and exit (no PDF generated)')
     parser.add_argument('--deck-state', type=str, default=None,
-                        help='Path to deck-state.json (default: deck-state.json next to cards.csv)')
+                        help='Path to deck-state.json (default: next to selected deck CSV)')
     args = parser.parse_args()
 
     base_dir = Path(__file__).parent
@@ -522,55 +594,22 @@ def main():
     images_dir = base_dir / "images"
     personal_dir = get_personal_images_dir(args.personal_dir)
     output_path = base_dir / args.output
+    deck_state_path = Path(args.deck_state) if args.deck_state else csv_path.parent / "deck-state.json"
 
-    # Resolve deck state path
-    deck_state_path = Path(args.deck_state) if args.deck_state else csv_path.parent / 'deck-state.json'
-
-    # --status: print deck summary and exit
     if args.status:
-        state = load_deck_state(deck_state_path)
-        if state is None:
-            print(f"No deck-state.json found at {deck_state_path}")
-            print("Run some print sessions to start tracking your deck.")
-        else:
-            try:
-                cards = load_cards(csv_path)
-            except FileNotFoundError:
-                print(f"Error: CSV file not found: {csv_path}")
-                sys.exit(1)
-            csv_words = {c['word'] for c in cards}
-            warnings = validate_deck_state(state, csv_words)
-            if warnings:
-                print("Warnings:")
-                for w in warnings:
-                    print(f"  ⚠ {w}")
-                print()
-            printed = state.get('printed_cards', [])
-            printed_words = {e.get('word') for e in printed if e.get('word')}
-            not_printed = csv_words - printed_words
-            print(f"Active cards in deck.csv: {len(csv_words)}")
-            print(f"Printed cards in inventory: {len(printed)}")
-            if printed_words:
-                print(f"Printed: {', '.join(sorted(printed_words))}")
-            if not_printed:
-                print(f"Not yet printed ({len(not_printed)}): {', '.join(sorted(not_printed))}")
-            else:
-                print("All active cards have been printed.")
-            sessions = state.get('sessions', [])
-            print(f"Recorded sessions: {len(sessions)}")
-            next_batch = state.get('next_batch', [])
-            if next_batch:
-                print(f"Next planned batch: {', '.join(next_batch)}")
-        sys.exit(0)
+        sys.exit(print_deck_status(csv_path, deck_state_path))
 
-    # Startup validation: warn about deck state issues, but don't abort
-    state = load_deck_state(deck_state_path)
-    if state is not None:
-        cards_for_validation = load_cards(csv_path)
-        csv_words = {c['word'] for c in cards_for_validation}
-        warnings = validate_deck_state(state, csv_words)
-        for w in warnings:
-            print(f"⚠ deck-state warning: {w}")
+    state, state_error = read_deck_state(deck_state_path)
+    if state_error:
+        print(f"⚠ deck-state warning: could not read {deck_state_path}: {state_error}")
+    elif state is not None:
+        try:
+            csv_words = load_all_deck_words(csv_path)
+        except FileNotFoundError:
+            print(f"Error: deck CSV not found: {csv_path}")
+            sys.exit(1)
+        for warning in validate_deck_state(state, csv_words):
+            print(f"⚠ deck-state warning: {warning}")
 
     # Register fonts
     available_fonts = register_fonts()

--- a/generate.py
+++ b/generate.py
@@ -34,6 +34,7 @@ from reportlab.pdfgen import canvas
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from PIL import Image
+from deck_state import load_deck_state, validate_deck_state
 
 # ── Config ──────────────────────────────────────────────────────────
 
@@ -510,6 +511,10 @@ def main():
                         help='Directory for personal photos (default: ~/.lettercards/personal/)')
     parser.add_argument('--safe-letters-only', action='store_true',
                         help='Exclude any letter that has at least one personal=yes card (useful for screenshots)')
+    parser.add_argument('--status', action='store_true',
+                        help='Show deck status summary and exit (no PDF generated)')
+    parser.add_argument('--deck-state', type=str, default=None,
+                        help='Path to deck-state.json (default: deck-state.json next to cards.csv)')
     args = parser.parse_args()
 
     base_dir = Path(__file__).parent
@@ -517,6 +522,51 @@ def main():
     images_dir = base_dir / "images"
     personal_dir = get_personal_images_dir(args.personal_dir)
     output_path = base_dir / args.output
+
+    # Resolve deck state path
+    deck_state_path = Path(args.deck_state) if args.deck_state else csv_path.parent / 'deck-state.json'
+
+    # --status: print deck summary and exit
+    if args.status:
+        state = load_deck_state(deck_state_path)
+        if state is None:
+            print(f"No deck-state.json found at {deck_state_path}")
+            print("Run some print sessions to start tracking your deck.")
+        else:
+            cards = load_cards(csv_path)
+            csv_words = {c['word'] for c in cards}
+            warnings = validate_deck_state(state, csv_words)
+            if warnings:
+                print("Warnings:")
+                for w in warnings:
+                    print(f"  ⚠ {w}")
+                print()
+            printed = state.get('printed_cards', [])
+            printed_words = {e.get('word') for e in printed}
+            not_printed = csv_words - printed_words
+            print(f"Active cards in deck.csv: {len(csv_words)}")
+            print(f"Printed cards in inventory: {len(printed)}")
+            if printed_words:
+                print(f"Printed: {', '.join(sorted(printed_words))}")
+            if not_printed:
+                print(f"Not yet printed ({len(not_printed)}): {', '.join(sorted(not_printed))}")
+            else:
+                print("All active cards have been printed.")
+            sessions = state.get('sessions', [])
+            print(f"Recorded sessions: {len(sessions)}")
+            next_batch = state.get('next_batch', [])
+            if next_batch:
+                print(f"Next planned batch: {', '.join(next_batch)}")
+        sys.exit(0)
+
+    # Startup validation: warn about deck state issues, but don't abort
+    state = load_deck_state(deck_state_path)
+    if state is not None:
+        cards_for_validation = load_cards(csv_path)
+        csv_words = {c['word'] for c in cards_for_validation}
+        warnings = validate_deck_state(state, csv_words)
+        for w in warnings:
+            print(f"⚠ deck-state warning: {w}")
 
     # Register fonts
     available_fonts = register_fonts()

--- a/tests/test_deck_state.py
+++ b/tests/test_deck_state.py
@@ -79,3 +79,14 @@ def test_validate_no_warning_when_printed_cards_empty():
     state = {"deck_protocol": "1.0", "printed_cards": []}
     warnings = validate_deck_state(state, {"appel"})
     assert warnings == []
+
+
+def test_validate_returns_empty_for_none_state():
+    warnings = validate_deck_state(None, {"appel"})
+    assert warnings == []
+
+
+def test_validate_warns_when_printed_cards_not_a_list():
+    state = {"deck_protocol": "1.0", "printed_cards": "not a list"}
+    warnings = validate_deck_state(state, set())
+    assert any("not a list" in w or "corrupt" in w for w in warnings)

--- a/tests/test_deck_state.py
+++ b/tests/test_deck_state.py
@@ -90,3 +90,81 @@ def test_validate_warns_when_printed_cards_not_a_list():
     state = {"deck_protocol": "1.0", "printed_cards": "not a list"}
     warnings = validate_deck_state(state, set())
     assert any("not a list" in w or "corrupt" in w for w in warnings)
+
+
+# ── generate.py integration ───────────────────────────────────────────────────
+
+import subprocess
+import sys
+
+
+def write_csv_for_status(tmp_path, rows="a,appel,appel.png,,no\nd,deur,deur.png,,no\n"):
+    csv_file = tmp_path / "cards.csv"
+    csv_file.write_text("letter,word,image,font,personal\n" + rows, encoding="utf-8")
+    return csv_file
+
+
+def test_status_flag_prints_summary(tmp_path):
+    write_csv_for_status(tmp_path)
+    state = {
+        "deck_protocol": "1.0",
+        "printed_cards": [{"word": "appel", "printed_date": "2026-03-20"}],
+        "sessions": [],
+    }
+    (tmp_path / "deck-state.json").write_text(json.dumps(state), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--status",
+         "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(tmp_path / "deck-state.json")],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "appel" in result.stdout
+    assert "printed" in result.stdout.lower()
+
+
+def test_status_flag_works_without_deck_state_file(tmp_path):
+    write_csv_for_status(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--status",
+         "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(tmp_path / "nonexistent.json")],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "no deck-state" in result.stdout.lower() or "not found" in result.stdout.lower()
+
+
+def test_startup_validation_prints_warning_for_unknown_protocol(tmp_path):
+    write_csv_for_status(tmp_path)
+    state = {"deck_protocol": "99.0", "printed_cards": []}
+    (tmp_path / "deck-state.json").write_text(json.dumps(state), encoding="utf-8")
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--no-placeholders",
+         "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(tmp_path / "deck-state.json"),
+         "--output", str(tmp_path / "out.pdf")],
+        capture_output=True, text=True
+    )
+    assert "99.0" in result.stdout or "99.0" in result.stderr
+
+
+def test_startup_validation_no_warning_when_state_missing(tmp_path):
+    write_csv_for_status(tmp_path)
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--no-placeholders",
+         "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(tmp_path / "nonexistent.json"),
+         "--output", str(tmp_path / "out.pdf")],
+        capture_output=True, text=True
+    )
+    assert "deck_protocol" not in result.stdout
+    assert "deck_protocol" not in result.stderr

--- a/tests/test_deck_state.py
+++ b/tests/test_deck_state.py
@@ -1,0 +1,81 @@
+"""Tests for deck_state.py — load and validate deck-state.json."""
+import json
+import pytest
+from pathlib import Path
+
+from deck_state import load_deck_state, validate_deck_state
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def write_state(tmp_path, data):
+    p = tmp_path / "deck-state.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+# ── load_deck_state ───────────────────────────────────────────────────────────
+
+def test_load_deck_state_returns_dict_for_valid_file(tmp_path):
+    p = write_state(tmp_path, {"deck_protocol": "1.0", "printed_cards": []})
+    result = load_deck_state(p)
+    assert isinstance(result, dict)
+    assert result["deck_protocol"] == "1.0"
+
+
+def test_load_deck_state_returns_none_when_file_missing(tmp_path):
+    result = load_deck_state(tmp_path / "nonexistent.json")
+    assert result is None
+
+
+def test_load_deck_state_returns_none_for_invalid_json(tmp_path):
+    p = tmp_path / "deck-state.json"
+    p.write_text("not valid json {{{")
+    result = load_deck_state(p)
+    assert result is None
+
+
+# ── validate_deck_state ───────────────────────────────────────────────────────
+
+def test_validate_no_warnings_for_valid_state(tmp_path):
+    state = {
+        "deck_protocol": "1.0",
+        "printed_cards": [{"word": "appel"}, {"word": "deur"}],
+    }
+    csv_words = {"appel", "deur", "eend"}
+    warnings = validate_deck_state(state, csv_words)
+    assert warnings == []
+
+
+def test_validate_warns_when_deck_protocol_missing():
+    state = {"printed_cards": []}
+    warnings = validate_deck_state(state, set())
+    assert any("deck_protocol" in w for w in warnings)
+
+
+def test_validate_warns_when_deck_protocol_version_mismatch():
+    state = {"deck_protocol": "99.0", "printed_cards": []}
+    warnings = validate_deck_state(state, set())
+    assert any("99.0" in w for w in warnings)
+
+
+def test_validate_no_warning_for_supported_protocol():
+    state = {"deck_protocol": "1.0", "printed_cards": []}
+    warnings = validate_deck_state(state, set())
+    assert not any("deck_protocol" in w for w in warnings)
+
+
+def test_validate_warns_for_printed_card_not_in_csv():
+    state = {
+        "deck_protocol": "1.0",
+        "printed_cards": [{"word": "wolf"}],
+    }
+    csv_words = {"appel", "deur"}
+    warnings = validate_deck_state(state, csv_words)
+    assert any("wolf" in w for w in warnings)
+
+
+def test_validate_no_warning_when_printed_cards_empty():
+    state = {"deck_protocol": "1.0", "printed_cards": []}
+    warnings = validate_deck_state(state, {"appel"})
+    assert warnings == []

--- a/tests/test_deck_state.py
+++ b/tests/test_deck_state.py
@@ -1,9 +1,7 @@
 """Tests for deck_state.py — load and validate deck-state.json."""
 import json
-import pytest
-from pathlib import Path
 
-from deck_state import load_deck_state, validate_deck_state
+from deck_state import load_deck_state, read_deck_state, validate_deck_state
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -33,6 +31,14 @@ def test_load_deck_state_returns_none_for_invalid_json(tmp_path):
     p.write_text("not valid json {{{")
     result = load_deck_state(p)
     assert result is None
+
+
+def test_read_deck_state_returns_error_for_invalid_json(tmp_path):
+    p = tmp_path / "deck-state.json"
+    p.write_text("not valid json {{{")
+    state, error = read_deck_state(p)
+    assert state is None
+    assert error is not None
 
 
 # ── validate_deck_state ───────────────────────────────────────────────────────
@@ -92,6 +98,13 @@ def test_validate_warns_when_printed_cards_not_a_list():
     assert any("not a list" in w or "corrupt" in w for w in warnings)
 
 
+def test_validate_warns_when_printed_card_entry_malformed():
+    state = {"deck_protocol": "1.0", "printed_cards": ["wolf", {"printed_date": "2026-03-20"}]}
+    warnings = validate_deck_state(state, {"wolf"})
+    assert any("printed_cards[0]" in w for w in warnings)
+    assert any("printed_cards[1]" in w for w in warnings)
+
+
 # ── generate.py integration ───────────────────────────────────────────────────
 
 import subprocess
@@ -120,8 +133,32 @@ def test_status_flag_prints_summary(tmp_path):
         capture_output=True, text=True
     )
     assert result.returncode == 0
-    assert "appel" in result.stdout
-    assert "printed" in result.stdout.lower()
+    assert "Active cards in selected deck: 2" in result.stdout
+    assert "Printed cards in inventory: 1" in result.stdout
+    assert "Distinct printed words: 1" in result.stdout
+
+
+def test_status_flag_does_not_warn_for_retired_printed_cards_still_in_csv(tmp_path):
+    csv_file = tmp_path / "deck.csv"
+    csv_file.write_text(
+        "letter,word,image,font,personal,status,notes,language\n"
+        "w,wolf,wolf.png,,no,retired,,nl\n"
+        "a,appel,appel.png,,no,active,,nl\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "deck-state.json").write_text(
+        json.dumps({"deck_protocol": "1.0", "printed_cards": [{"word": "wolf"}], "sessions": []}),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--status",
+         "--csv", str(csv_file),
+         "--deck-state", str(tmp_path / "deck-state.json")],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "not in cards.csv" not in result.stdout
 
 
 def test_status_flag_works_without_deck_state_file(tmp_path):
@@ -135,6 +172,32 @@ def test_status_flag_works_without_deck_state_file(tmp_path):
     )
     assert result.returncode == 0
     assert "no deck-state" in result.stdout.lower() or "not found" in result.stdout.lower()
+
+
+def test_status_flag_fails_when_csv_missing_even_if_deck_state_missing(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--status",
+         "--csv", str(tmp_path / "missing.csv"),
+         "--deck-state", str(tmp_path / "nonexistent.json")],
+        capture_output=True, text=True
+    )
+    assert result.returncode != 0
+    assert "deck CSV not found" in result.stdout
+
+
+def test_status_flag_reports_corrupt_deck_state(tmp_path):
+    write_csv_for_status(tmp_path)
+    p = tmp_path / "deck-state.json"
+    p.write_text("not valid json {{{", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--status",
+         "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(p)],
+        capture_output=True, text=True
+    )
+    assert result.returncode != 0
+    assert "could not read deck-state.json" in result.stdout
 
 
 def test_startup_validation_prints_warning_for_unknown_protocol(tmp_path):
@@ -168,3 +231,20 @@ def test_startup_validation_no_warning_when_state_missing(tmp_path):
     )
     assert "deck_protocol" not in result.stdout
     assert "deck_protocol" not in result.stderr
+
+
+def test_startup_validation_warns_for_corrupt_deck_state(tmp_path):
+    write_csv_for_status(tmp_path)
+    p = tmp_path / "deck-state.json"
+    p.write_text("not valid json {{{", encoding="utf-8")
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+
+    result = subprocess.run(
+        [sys.executable, "generate.py", "--no-placeholders",
+         "--csv", str(tmp_path / "cards.csv"),
+         "--deck-state", str(p),
+         "--output", str(tmp_path / "out.pdf")],
+        capture_output=True, text=True
+    )
+    assert "could not read" in result.stdout or "could not read" in result.stderr


### PR DESCRIPTION
Implements Phase 1b from [docs/architecture.md](docs/architecture.md). Closes #101.

## Summary

- add `deck_state.py` to load `deck-state.json` and return warning-only validation results
- add `deck-state.example.json` as the `1.0` protocol reference
- add `deck-state.json` to `.gitignore` because runtime deck state belongs to the user deck, not the engine repo
- wire `generate.py` to support `--status` and `--deck-state`
- validate deck state on normal runs without blocking PDF generation
- keep inventory semantics intact: `printed_cards` remains a list and may contain duplicates
- add dedicated tests in `tests/test_deck_state.py`

## Validation implemented

`validate_deck_state()` currently warns for:

- missing `deck_protocol`
- unsupported `deck_protocol`
- non-list `printed_cards`
- malformed `printed_cards` entries
- `printed_cards[*].word` values not present in the selected deck CSV

This is intentionally shallow validation for Phase 1b. Full schema validation and broader deck integrity checks remain future work.

## Status output behavior

`python generate.py --status` now:

- resolves `deck-state.json` next to the selected `--csv` file unless `--deck-state` is passed explicitly
- prints a human-readable summary and exits without generating a PDF
- reports active card count, printed inventory count, distinct printed words, unprinted words, session count, and next planned batch
- refers to the selected deck generically rather than hardcoding `cards.csv`

## How to verify

```bash
python3 -m venv venv
source venv/bin/activate
pip install -r requirements.txt

venv/bin/pytest tests/test_deck_state.py -q
venv/bin/pytest tests/test_generate.py -q
venv/bin/pytest tests/ -q
```

Expected results from this implementation:

- `tests/test_deck_state.py`: 14 passed
- `tests/test_generate.py`: 30 passed
- full suite: 52 passed

### Manual smoke checks

```bash
python generate.py --status
# If no deck-state.json exists next to the selected deck CSV:
# -> prints a graceful "No deck-state.json found ..." message and exits 0

cp deck-state.example.json deck-state.json
python generate.py --status
# -> prints counts for active cards, printed inventory, sessions, and next batch

python generate.py --no-placeholders --deck-state deck-state.json
# -> normal generation still runs; any deck-state problems are warnings only
```

## Notes

- scope stays inside `#101`; this does not implement the later `lettercards status` CLI from `#102`
- protocol mismatch is warning-only in this PR, even though the longer-term architecture may later hard-fail incompatible versions
