### PR TITLE
Scope gh CLI to fine-grained PAT + read-only allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,14 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh api user *)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 letterkaarten.pdf
 .tmp/
 .worktrees/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 venv/
 letterkaarten.pdf
 .tmp/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -29,3 +29,55 @@ See [CLAUDE.md](CLAUDE.md) for full documentation:
 - Personal photo workflow
 - Font and color configuration
 - Architecture details
+
+## Developer setup
+
+After cloning, you need two things beyond the Quick Start above: a Python virtual environment (already covered) and a GitHub CLI token scoped to this repo only.
+
+### GitHub CLI — fine-grained PAT
+
+The `gh` CLI must use a **fine-grained personal access token** scoped to this repository only. A classic OAuth token grants full admin access (merge bypassing branch protection, delete repo, manage webhooks) — do not use one.
+
+**Create the token:**
+
+1. Go to GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
+2. Click **Generate new token**
+3. Set **Resource owner** to your account and **Repository access** to this repo only (`lettercards`)
+4. Grant these permissions — nothing else:
+
+| Permission | Access |
+|---|---|
+| Contents | Read and write |
+| Pull requests | Read and write |
+| Issues | Read and write |
+| Actions | Read-only |
+| Metadata | Read-only (required, auto-selected) |
+
+5. Generate the token and copy it.
+
+**Configure a separate gh config dir** so Claude's token doesn't overwrite your personal one.
+
+Create `.claude/settings.local.json` in the repo root (this file is gitignored — each developer has their own):
+
+```json
+{
+  "env": {
+    "GH_CONFIG_DIR": "/Users/yourname/.config/gh-claude"
+  }
+}
+```
+
+**Authenticate into that config dir:**
+
+```bash
+echo "YOUR_TOKEN" | GH_CONFIG_DIR=~/.config/gh-claude gh auth login --with-token
+```
+
+**Verify:**
+
+```bash
+GH_CONFIG_DIR=~/.config/gh-claude gh auth status
+GH_CONFIG_DIR=~/.config/gh-claude gh pr list
+```
+
+`gh auth status` should show the token is scoped to this repo. `gh pr list` should work. `gh pr merge --admin` should now fail with a 403. Your regular `gh` CLI is unaffected.


### PR DESCRIPTION
Closes #109

## What changed

Three changes towards scoping Claude's gh CLI access:

**Read-only `gh` commands allowed without prompting** (`.claude/settings.json`)
Adds `permissions.allow` rules for `gh issue/pr list+view`, `gh pr checks`, and `gh api user` so routine GitHub reads don't interrupt the workflow.

**Fine-grained PAT setup documented** (`README.md`)
Adds a Developer Setup section explaining how to create a repo-scoped fine-grained PAT and authenticate it into a separate `GH_CONFIG_DIR` (`~/.config/gh-claude`) so Claude's token doesn't overwrite the developer's personal `gh` config.

**`settings.local.json` gitignored** (`.gitignore`)
Each developer creates their own `.claude/settings.local.json` pointing `GH_CONFIG_DIR` to their local token — this file must not be committed.

## Verification

Tested with a fine-grained PAT scoped to Contents/PRs/Issues/Actions/Metadata only:

```
$ GH_CONFIG_DIR=/Users/jeroen/.config/gh-claude gh api repos/jvspl/lettercards/hooks
{"message":"Resource not accessible by personal access token","status":"403"}
```

Admin operations (webhooks, branch protection, repo delete) return 403. `gh pr list` and `gh pr checks` work.

Note: the existing personal token also returned 403 for the hooks endpoint, confirming it was already a fine-grained PAT — the classic OAuth concern from the issue description didn't apply. The isolation (separate `GH_CONFIG_DIR`) is still valuable regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
