### PR TITLE
Clarify developer setup and GitHub auth workflows in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,18 +55,6 @@ bash tests/test_hooks.sh
 gh pr create --draft --body-file .tmp/pr-body.md   # then: rm .tmp/pr-body.md
 ```
 
-### Runtime compatibility (Desktop + Cloud)
-
-Use this operational order depending on the runtime:
-
-1. **Built-in GitHub integration (MCP/server/UI)** if available.
-2. **`gh` CLI** if available (desktop/local default).
-3. **Manual publish fallback** if neither is available: prepare commits + PR text, then ask the operator to publish via UI.
-
-Always separate:
-- **PR preparation** (code, commit(s), PR title/body draft)
-- **PR publication** (actual PR opened on GitHub)
-
 **Tests:** Run both suites before every PR touching `generate.py`, `process_photo.py`, or `.claude/hooks/`. For visual changes also run `python generate.py --letters d,e,w --safe-letters-only` and inspect the PDF.
 
 **PR scope:** Check `gh pr list` + `git branch` before starting. Same topic → same branch. Different topic → new branch + new PR. Unsure → ask the operator.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,18 @@ bash tests/test_hooks.sh
 gh pr create --draft --body-file .tmp/pr-body.md   # then: rm .tmp/pr-body.md
 ```
 
+### Runtime compatibility (Desktop + Cloud)
+
+Use this operational order depending on the runtime:
+
+1. **Built-in GitHub integration (MCP/server/UI)** if available.
+2. **`gh` CLI** if available (desktop/local default).
+3. **Manual publish fallback** if neither is available: prepare commits + PR text, then ask the operator to publish via UI.
+
+Always separate:
+- **PR preparation** (code, commit(s), PR title/body draft)
+- **PR publication** (actual PR opened on GitHub)
+
 **Tests:** Run both suites before every PR touching `generate.py`, `process_photo.py`, or `.claude/hooks/`. For visual changes also run `python generate.py --letters d,e,w --safe-letters-only` and inspect the PDF.
 
 **PR scope:** Check `gh pr list` + `git branch` before starting. Same topic → same branch. Different topic → new branch + new PR. Unsure → ask the operator.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Use this order of preference:
 
 This keeps the repo usable whether work is done by Codex, Claude Code, or human developers, and whether the runtime is desktop or web/cloud.
 
+### Agent compatibility notes
+
+- In some web/cloud runtimes, creating the **actual GitHub PR** is a manual UI step (e.g., clicking "Create PR"), even when the agent has prepared commits and PR text.
+- In desktop/local runtimes with `gh` configured, PR creation can be fully CLI-driven (`gh pr create`).
+- When in doubt, treat PR draft text generation and PR publication as two separate steps.
+
 ### GitHub CLI — fine-grained PAT (desktop/local mode)
 
 If you are using the `gh` CLI, use a **fine-grained personal access token** scoped to this repository only. A classic OAuth token grants full admin access (merge bypassing branch protection, delete repo, manage webhooks) — do not use one.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,25 @@ See [CLAUDE.md](CLAUDE.md) for full documentation:
 
 ## Developer setup
 
-After cloning, you need two things beyond the Quick Start above: a Python virtual environment (already covered) and a GitHub CLI token scoped to this repo only.
+After cloning, the baseline requirement is a Python virtual environment (already covered in Quick Start).
 
-### GitHub CLI — fine-grained PAT
+GitHub tooling is environment-dependent:
+- **Desktop/local workflows (human devs, Claude Code Desktop):** `gh` is recommended.
+- **Web/cloud agent workflows (Codex Cloud or similar):** built-in integrations may replace `gh`.
 
-The `gh` CLI must use a **fine-grained personal access token** scoped to this repository only. A classic OAuth token grants full admin access (merge bypassing branch protection, delete repo, manage webhooks) — do not use one.
+### GitHub access modes (tool-agnostic)
+
+Use this order of preference:
+
+1. **Built-in platform integration** (MCP/server tools) when available.
+2. **`gh` CLI** for local/desktop workflows.
+3. **Repository-local fallback** (no GitHub API) for analysis/docs work when remote access is unavailable.
+
+This keeps the repo usable whether work is done by Codex, Claude Code, or human developers, and whether the runtime is desktop or web/cloud.
+
+### GitHub CLI — fine-grained PAT (desktop/local mode)
+
+If you are using the `gh` CLI, use a **fine-grained personal access token** scoped to this repository only. A classic OAuth token grants full admin access (merge bypassing branch protection, delete repo, manage webhooks) — do not use one.
 
 **Create the token:**
 

--- a/docs/adr/001-persona-orchestration.md
+++ b/docs/adr/001-persona-orchestration.md
@@ -97,16 +97,6 @@ Issues are the coordination layer. The orchestrator polls `gh issue list` and ro
 | `persona:architect` | Architect |
 | `needs:review` | Architect (cross-cutting review) |
 
-#### Transport abstraction for different runtimes
-
-The orchestration model depends on GitHub data/actions, but not on one specific transport. Runtime preference order:
-
-1. **Built-in integration (MCP/API/UI bridge)** when available.
-2. **`gh` CLI** in desktop/local environments.
-3. **Operator-assisted/manual fallback** when direct integration is unavailable.
-
-This preserves the same persona routing model while making execution portable across Claude Desktop, Codex Cloud, and human-operated workflows.
-
 Handoffs use issue comments and PR labels. When the Engineer opens a PR, it adds `needs:designer-review` — the orchestrator picks this up next session and invokes the Designer subagent.
 
 ### Orchestrator responsibilities

--- a/docs/adr/001-persona-orchestration.md
+++ b/docs/adr/001-persona-orchestration.md
@@ -97,6 +97,16 @@ Issues are the coordination layer. The orchestrator polls `gh issue list` and ro
 | `persona:architect` | Architect |
 | `needs:review` | Architect (cross-cutting review) |
 
+#### Transport abstraction for different runtimes
+
+The orchestration model depends on GitHub data/actions, but not on one specific transport. Runtime preference order:
+
+1. **Built-in integration (MCP/API/UI bridge)** when available.
+2. **`gh` CLI** in desktop/local environments.
+3. **Operator-assisted/manual fallback** when direct integration is unavailable.
+
+This preserves the same persona routing model while making execution portable across Claude Desktop, Codex Cloud, and human-operated workflows.
+
 Handoffs use issue comments and PR labels. When the Engineer opens a PR, it adds `needs:designer-review` — the orchestrator picks this up next session and invokes the Designer subagent.
 
 ### Orchestrator responsibilities

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,8 +313,6 @@ The file tracks:
 
 The conversational interface is not a feature to build — it is a protocol to design for. The engine and deck format are structured so that any Claude surface can act as an effective deck manager.
 
-The protocol is also runtime-agnostic: any agentic environment (Claude surfaces, Codex cloud/web, or human-operated tooling) can participate if it can (a) read/write deck files and (b) interact with GitHub through built-in integrations, CLI tooling, or operator-assisted manual handoff.
-
 **The interface is defined by two artifacts:**
 
 **1. Content-mode project knowledge.** A CLAUDE.md (or Claude.ai Project knowledge file) that tells Claude how to behave as a deck assistant. It covers how to read and modify `deck.csv` and `deck-state.json`, what questions to ask during a review session, how to suggest new words, how to plan a print batch, and how to record feedback and update card status.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,6 +313,8 @@ The file tracks:
 
 The conversational interface is not a feature to build — it is a protocol to design for. The engine and deck format are structured so that any Claude surface can act as an effective deck manager.
 
+The protocol is also runtime-agnostic: any agentic environment (Claude surfaces, Codex cloud/web, or human-operated tooling) can participate if it can (a) read/write deck files and (b) interact with GitHub through built-in integrations, CLI tooling, or operator-assisted manual handoff.
+
 **The interface is defined by two artifacts:**
 
 **1. Content-mode project knowledge.** A CLAUDE.md (or Claude.ai Project knowledge file) that tells Claude how to behave as a deck assistant. It covers how to read and modify `deck.csv` and `deck-state.json`, what questions to ask during a review session, how to suggest new words, how to plan a print batch, and how to record feedback and update card status.


### PR DESCRIPTION
### Motivation
- Make the Developer setup instructions tool-agnostic and safer by clarifying recommended GitHub access modes for different runtimes (desktop vs cloud/agent). 
- Reduce risk from misuse of overly-permissive tokens by emphasizing fine-grained PATs and repository-scoped permissions. 
- Ensure the README explicitly references the existing Quick Start venv requirement to avoid duplication. 

### Description
- Rewrote the Developer setup section to state the baseline requirement is a Python virtual environment and to introduce environment-dependent GitHub tooling guidance. 
- Added a `GitHub access modes` ordering that prefers built-in platform integrations, then `gh` for local workflows, and a repository-local fallback for no-remote scenarios. 
- Preserved and relocated the `gh` CLI fine-grained personal access token instructions and the permissions table, and kept guidance to configure `.claude/settings.local.json` for local token isolation. 
- Rephrased several headings and added notes to clarify differences between desktop/local and web/cloud agent workflows. 

### Testing
- This is a documentation-only change, so no automated tests were required or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2aaacef4832ea0d39f04f1ff3cf9)