### PR TITLE
Add review session logging and learning-progress tracking to deck-state and CLI

### DIFF
--- a/deck_state.py
+++ b/deck_state.py
@@ -12,6 +12,13 @@ import json
 from pathlib import Path
 
 SUPPORTED_PROTOCOL = "1.0"
+LETTER_STATUSES = [
+    "not_introduced",
+    "introduced",
+    "learning",
+    "recognized",
+    "mastered",
+]
 
 
 def read_deck_state(path: Path) -> tuple[dict | None, str | None]:
@@ -38,6 +45,25 @@ def load_deck_state(path: Path) -> dict | None:
     """Load deck-state.json, returning None when the file is missing or invalid."""
     state, _error = read_deck_state(path)
     return state
+
+
+def default_deck_state() -> dict:
+    """Return a minimal valid deck-state structure."""
+    return {
+        "deck_protocol": SUPPORTED_PROTOCOL,
+        "printed_cards": [],
+        "sessions": [],
+        "progress": {"letters": {}, "summary_snapshots": []},
+    }
+
+
+def write_deck_state(path: Path, state: dict) -> None:
+    """Persist deck-state.json atomically."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temp = target.with_suffix(".tmp")
+    temp.write_text(json.dumps(state, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    temp.replace(target)
 
 
 def validate_deck_state(state: dict | None, csv_words: set[str]) -> list[str]:
@@ -96,3 +122,106 @@ def validate_deck_state(state: dict | None, csv_words: set[str]) -> list[str]:
                 )
 
     return warnings
+
+
+def _ensure_progress_letter(state: dict, letter: str, date: str) -> dict:
+    progress = state.setdefault("progress", {})
+    letters = progress.setdefault("letters", {})
+    letter_progress = letters.setdefault(
+        letter,
+        {
+            "status": "not_introduced",
+            "first_introduced": date,
+            "observations": [],
+            "evidence_count": 0,
+        },
+    )
+    letter_progress.setdefault("status", "not_introduced")
+    letter_progress.setdefault("first_introduced", date)
+    letter_progress.setdefault("observations", [])
+    letter_progress.setdefault("evidence_count", 0)
+    return letter_progress
+
+
+def _step_status(current: str, delta: int) -> str:
+    if current not in LETTER_STATUSES:
+        current = "not_introduced"
+    index = LETTER_STATUSES.index(current)
+    next_index = max(0, min(len(LETTER_STATUSES) - 1, index + delta))
+    return LETTER_STATUSES[next_index]
+
+
+def append_review_session(state: dict, session: dict, *, date: str) -> dict:
+    """Append a normalized review session to deck-state and update letter progress."""
+    sessions = state.setdefault("sessions", [])
+    sessions.append(
+        {
+            "date": date,
+            "type": "review",
+            "duration_minutes": session.get("duration_minutes"),
+            "letters_played": session.get("letters_played", []),
+            "observations": session.get("observations", []),
+        }
+    )
+    update_progress_from_review(state, session, date=date)
+    return state
+
+
+def update_progress_from_review(state: dict, session: dict, *, date: str) -> dict:
+    """
+    Update per-letter learning progress from a review session.
+
+    Positive reactions gradually move a letter forward up to mastered.
+    Confused/avoidant reactions move a letter one step backward (never below not_introduced).
+    """
+    for letter in session.get("letters_played", []):
+        letter_progress = _ensure_progress_letter(state, letter, date)
+        if letter_progress["status"] == "not_introduced":
+            letter_progress["status"] = "introduced"
+
+    for observation in session.get("observations", []):
+        card = observation.get("card", "")
+        reaction = observation.get("reaction", "")
+        note = observation.get("notes", "")
+        if not isinstance(card, str) or not card:
+            continue
+        letter = card[0].lower()
+        letter_progress = _ensure_progress_letter(state, letter, date)
+        letter_progress["observations"].append({"date": date, "note": note or reaction})
+
+        if reaction in {"positive", "recognized"}:
+            letter_progress["evidence_count"] += 1
+            if letter_progress["evidence_count"] >= 4:
+                letter_progress["status"] = "mastered"
+            elif letter_progress["evidence_count"] >= 2:
+                letter_progress["status"] = _step_status(letter_progress["status"], 2)
+            else:
+                letter_progress["status"] = _step_status(letter_progress["status"], 1)
+        elif reaction in {"confused", "avoidant"}:
+            letter_progress["status"] = _step_status(letter_progress["status"], -1)
+    return state
+
+
+def summarize_learning_progress(state: dict) -> dict:
+    """Return a compact progress summary suitable for caregiver-facing reporting."""
+    letters = state.get("progress", {}).get("letters", {})
+    recognized = sorted([k for k, v in letters.items() if v.get("status") in {"recognized", "mastered"}])
+    learning = sorted([k for k, v in letters.items() if v.get("status") in {"introduced", "learning"}])
+    confused_recent = sorted(
+        [
+            k
+            for k, v in letters.items()
+            if any("confused" in str(o.get("note", "")).lower() for o in v.get("observations", [])[-3:])
+        ]
+    )
+    recommendation = (
+        "Focus next sessions on letters in progress."
+        if learning
+        else "Introduce one new letter with familiar words."
+    )
+    return {
+        "recognized_or_mastered": recognized,
+        "in_progress": learning,
+        "confused_recently": confused_recent,
+        "recommendation": recommendation,
+    }

--- a/lettercards/cli.py
+++ b/lettercards/cli.py
@@ -6,7 +6,14 @@ from pathlib import Path
 import generate
 import pictogram_workflow
 import process_photo
-from deck_state import read_deck_state, validate_deck_state
+from deck_state import (
+    append_review_session,
+    default_deck_state,
+    read_deck_state,
+    summarize_learning_progress,
+    validate_deck_state,
+    write_deck_state,
+)
 
 
 def default_csv_argument() -> str:
@@ -142,6 +149,59 @@ def cmd_deck_check(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_observations(values: list[str]) -> list[dict]:
+    observations: list[dict] = []
+    for value in values:
+        parts = value.split(":", 2)
+        if len(parts) < 2:
+            continue
+        card = parts[0].strip()
+        reaction = parts[1].strip().lower()
+        notes = parts[2].strip() if len(parts) == 3 else ""
+        if card and reaction:
+            observations.append({"card": card, "reaction": reaction, "notes": notes})
+    return observations
+
+
+def cmd_deck_review_log(args: argparse.Namespace) -> int:
+    deck_state_path = Path(args.deck_state)
+    state, state_error = read_deck_state(deck_state_path)
+    if state_error:
+        print(f"Error: could not read deck-state.json: {state_error}")
+        return 1
+    if state is None:
+        state = default_deck_state()
+
+    session = {
+        "duration_minutes": args.duration,
+        "letters_played": [letter.strip().lower() for letter in args.letters.split(",") if letter.strip()],
+        "observations": _parse_observations(args.observe or []),
+    }
+    append_review_session(state, session, date=args.date)
+    write_deck_state(deck_state_path, state)
+    print(f"Logged review session on {args.date} with {len(session['observations'])} observations.")
+    return 0
+
+
+def cmd_deck_review_summary(args: argparse.Namespace) -> int:
+    deck_state_path = Path(args.deck_state)
+    state, state_error = read_deck_state(deck_state_path)
+    if state_error:
+        print(f"Error: could not read deck-state.json: {state_error}")
+        return 1
+    if state is None:
+        print(f"No deck-state.json found at {deck_state_path}")
+        return 1
+
+    summary = summarize_learning_progress(state)
+    print("LEARNING PROGRESS SUMMARY")
+    print(f"Recognized/mastered: {', '.join(summary['recognized_or_mastered']) or '-'}")
+    print(f"In progress: {', '.join(summary['in_progress']) or '-'}")
+    print(f"Confused recently: {', '.join(summary['confused_recently']) or '-'}")
+    print(f"Recommendation: {summary['recommendation']}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Unified CLI for lettercards workflows")
     subparsers = parser.add_subparsers(dest="command")
@@ -203,6 +263,26 @@ def build_parser() -> argparse.ArgumentParser:
     deck_check_parser.add_argument("--deck-state", type=str, default=None, help="Path to deck-state.json")
     deck_check_parser.add_argument("--personal-dir", type=str, default=None, help="Directory for personal photos")
     deck_check_parser.set_defaults(func=cmd_deck_check)
+
+    review_parser = deck_subparsers.add_parser("review", help="Review session commands")
+    review_subparsers = review_parser.add_subparsers(dest="review_command")
+
+    review_log_parser = review_subparsers.add_parser("log", help="Log a review session")
+    review_log_parser.add_argument("--deck-state", type=str, required=True, help="Path to deck-state.json")
+    review_log_parser.add_argument("--date", type=str, required=True, help="Session date (YYYY-MM-DD)")
+    review_log_parser.add_argument("--duration", type=int, default=0, help="Session duration in minutes")
+    review_log_parser.add_argument("--letters", type=str, default="", help="Comma-separated letters played")
+    review_log_parser.add_argument(
+        "--observe",
+        action="append",
+        default=[],
+        help="Observation as 'card:reaction[:notes]' (repeatable)",
+    )
+    review_log_parser.set_defaults(func=cmd_deck_review_log)
+
+    review_summary_parser = review_subparsers.add_parser("summary", help="Show learning progress summary")
+    review_summary_parser.add_argument("--deck-state", type=str, required=True, help="Path to deck-state.json")
+    review_summary_parser.set_defaults(func=cmd_deck_review_summary)
 
     return parser
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,6 +51,18 @@ def test_deck_check_help_works():
     assert "Validate deck integrity" in result.stdout
 
 
+def test_deck_review_log_help_works():
+    result = run_cli("deck", "review", "log", "--help")
+    assert result.returncode == 0
+    assert "--observe" in result.stdout
+
+
+def test_deck_review_summary_help_works():
+    result = run_cli("deck", "review", "summary", "--help")
+    assert result.returncode == 0
+    assert "--deck-state" in result.stdout
+
+
 def test_status_command_runs_with_explicit_paths(tmp_path):
     csv_file = tmp_path / "deck.csv"
     csv_file.write_text(
@@ -81,3 +93,53 @@ def test_deck_check_reports_missing_images(tmp_path):
     result = run_cli("deck", "check", "--csv", str(csv_file))
     assert result.returncode != 0
     assert "Missing image for 'appel'" in result.stdout
+
+
+def test_deck_review_log_creates_state_and_updates_progress(tmp_path):
+    deck_state = tmp_path / "deck-state.json"
+    result = run_cli(
+        "deck",
+        "review",
+        "log",
+        "--deck-state",
+        str(deck_state),
+        "--date",
+        "2026-04-11",
+        "--duration",
+        "15",
+        "--letters",
+        "a,d",
+        "--observe",
+        "appel:positive:points and smiles",
+        "--observe",
+        "deur:confused:mixes with dier",
+    )
+    assert result.returncode == 0
+    state = json.loads(deck_state.read_text(encoding="utf-8"))
+    assert state["sessions"][-1]["type"] == "review"
+    assert "a" in state["progress"]["letters"]
+    assert "d" in state["progress"]["letters"]
+
+
+def test_deck_review_summary_outputs_recommendation(tmp_path):
+    deck_state = tmp_path / "deck-state.json"
+    deck_state.write_text(
+        json.dumps(
+            {
+                "deck_protocol": "1.0",
+                "printed_cards": [],
+                "sessions": [],
+                "progress": {
+                    "letters": {
+                        "a": {"status": "recognized", "observations": [{"note": "good"}]},
+                        "d": {"status": "learning", "observations": [{"note": "confused"}]},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = run_cli("deck", "review", "summary", "--deck-state", str(deck_state))
+    assert result.returncode == 0
+    assert "LEARNING PROGRESS SUMMARY" in result.stdout
+    assert "Recommendation:" in result.stdout

--- a/tests/test_deck_state.py
+++ b/tests/test_deck_state.py
@@ -1,7 +1,14 @@
 """Tests for deck_state.py — load and validate deck-state.json."""
 import json
 
-from deck_state import load_deck_state, read_deck_state, validate_deck_state
+from deck_state import (
+    append_review_session,
+    load_deck_state,
+    read_deck_state,
+    summarize_learning_progress,
+    update_progress_from_review,
+    validate_deck_state,
+)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -103,6 +110,50 @@ def test_validate_warns_when_printed_card_entry_malformed():
     warnings = validate_deck_state(state, {"wolf"})
     assert any("printed_cards[0]" in w for w in warnings)
     assert any("printed_cards[1]" in w for w in warnings)
+
+
+def test_append_review_session_appends_and_updates_progress():
+    state = {"deck_protocol": "1.0", "sessions": []}
+    session = {
+        "duration_minutes": 12,
+        "letters_played": ["a"],
+        "observations": [{"card": "appel", "reaction": "positive", "notes": "pointed quickly"}],
+    }
+    append_review_session(state, session, date="2026-04-11")
+    assert len(state["sessions"]) == 1
+    assert state["sessions"][0]["type"] == "review"
+    assert state["progress"]["letters"]["a"]["status"] in {"introduced", "learning"}
+
+
+def test_update_progress_from_review_promotes_after_positive_evidence():
+    state = {"deck_protocol": "1.0"}
+    session = {"letters_played": ["a"], "observations": [{"card": "appel", "reaction": "positive"}]}
+    update_progress_from_review(state, session, date="2026-04-11")
+    update_progress_from_review(state, session, date="2026-04-12")
+    assert state["progress"]["letters"]["a"]["status"] in {"learning", "recognized", "mastered"}
+    assert state["progress"]["letters"]["a"]["evidence_count"] >= 2
+
+
+def test_update_progress_from_review_can_step_back_on_confusion():
+    state = {"progress": {"letters": {"w": {"status": "recognized", "observations": [], "evidence_count": 3}}}}
+    session = {"letters_played": ["w"], "observations": [{"card": "wolf", "reaction": "confused"}]}
+    update_progress_from_review(state, session, date="2026-04-11")
+    assert state["progress"]["letters"]["w"]["status"] in {"learning", "introduced", "not_introduced"}
+
+
+def test_summarize_learning_progress_returns_recommendation():
+    state = {
+        "progress": {
+            "letters": {
+                "a": {"status": "recognized", "observations": [{"date": "2026-04-11", "note": "great"}]},
+                "d": {"status": "learning", "observations": [{"date": "2026-04-11", "note": "confused on deur"}]},
+            }
+        }
+    }
+    summary = summarize_learning_progress(state)
+    assert "a" in summary["recognized_or_mastered"]
+    assert "d" in summary["in_progress"]
+    assert summary["recommendation"]
 
 
 # ── generate.py integration ───────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Introduce machine-managed learning progress and session history to track letter learning and caregiver observations from review sessions.
- Provide CLI tools to log review sessions and produce caregiver-facing summaries of learning progress.

### Description
- Add new deck-state helpers in `deck_state.py`: `default_deck_state`, `write_deck_state`, `_ensure_progress_letter`, `_step_status`, `append_review_session`, `update_progress_from_review`, and `summarize_learning_progress`, plus `LETTER_STATUSES` for canonical statuses.
- Implement atomic persistence of `deck-state.json` with `write_deck_state` and provide a minimal default structure via `default_deck_state`.
- Extend `lettercards/cli.py` with review subcommands `deck review log` and `deck review summary`, a `_parse_observations` helper, and wire `append_review_session`, `summarize_learning_progress`, `read_deck_state`, and `write_deck_state` into the CLI flow.
- Update validation and existing CLI imports so existing `deck check`/`status` flows still work while adding review workflows.

### Testing
- Added unit tests in `tests/test_deck_state.py` for `append_review_session`, `update_progress_from_review`, and `summarize_learning_progress`, and they passed when run.
- Added CLI tests in `tests/test_cli.py` for `deck review log` and `deck review summary` help and behavior, and they passed when run.
- Existing CLI and validation tests (`test_status`, `test_deck_check`, etc.) were run and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da35aa15e8832e939e072823bd7683)