### PR TITLE
Add golden render test that asserts cards actually show (#13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "pymupdf"]
 
 [project.scripts]
 lettercards = "lettercards.cli:main"

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -97,6 +97,33 @@ def test_letter_colors_vowel_consonant_split():
         assert LETTER_COLORS[a] != LETTER_COLORS[b], f"{a}/{b} share a color"
 
 
+def test_rendered_page_actually_shows_a_card(tmp_path):
+    """Guard the central rule: a rendered page contains card ink and words,
+    not just a valid %PDF- header. Catches white-on-white and missing draws."""
+    fitz = pytest.importorskip("fitz")  # pymupdf, dev extra
+    from lettercards import layout as L
+    out = tmp_path / "z.pdf"
+    assert main(["render", "starter", "--cards", "zebra", "-o", str(out)]) == 0
+    page = fitz.open(out)[0]
+    assert "zebra" in page.get_text().lower()            # the word made it in
+    scale = 150 / 72
+    pix = page.get_pixmap(dpi=150)
+    x0, y0, cw, ch = (L.MARGIN_X * scale, L.MARGIN_Y * scale,  # top-left card box
+                      L.CARD_W * scale, L.CARD_H * scale)
+
+    def region(fx0, fy0, fx1, fy1):
+        xs = range(int(x0 + fx0 * cw), int(x0 + fx1 * cw), 2)
+        ys = range(int(y0 + fy0 * ch), int(y0 + fy1 * ch), 2)
+        px = [pix.pixel(x, y) for y in ys for x in xs]
+        return [sum(p[i] for p in px) / len(px) for i in range(3)], px
+
+    _, image_px = region(0.25, 0.15, 0.75, 0.6)          # picture area
+    assert min(sum(p) / 3 for p in image_px) < 120       # real ink, not white-on-cream
+    band, _ = region(0.2, 0.8, 0.8, 0.95)                # accent band
+    corner, _ = region(0.02, 0.02, 0.06, 0.08)           # bare card cream
+    assert corner[0] - band[0] > 20                      # band tint differs from background
+
+
 def test_cli_photo_crops_square(tmp_path):
     from PIL import Image
     src = tmp_path / "portrait.jpg"


### PR DESCRIPTION
Closes #13.

## Problem

The project's central rule is "PRs only for changes that could break rendering" — but the suite couldn't detect broken rendering. `test_cli_render_starter` only checks that the output starts with `%PDF-` and reports the right card count. A white-on-white word, a missing image draw, or a band covering the picture would all pass a green PR.

## Change

One new test, `test_rendered_page_actually_shows_a_card`, with two complementary cheap checks and no golden-file brittleness:

- **Text is present:** render a single card (`--cards zebra`), extract text via pymupdf, assert the word appears.
- **Ink is present where it should be:** rasterize page 1 at a fixed 150 dpi and assert (a) the picture area contains real dark ink (min brightness < 120 — a white-on-cream bug leaves ~247), and (b) the accent band's mean color differs from the bare card cream (Δred > 20; actual ~73).

Card geometry is derived from `layout` constants (scaled), so it tracks layout changes instead of hardcoding pixel coordinates. Assertions are tolerance-based region means, not byte-exact goldens.

Verified the guard actually guards: with the image draw stubbed to a no-op, the ink assertion flips from 7 → 247 and fails, as intended.

## Notes

- **Dev-dependency only:** adds `pymupdf` to the `[dev]` extra; the runtime engine gains no imports. Guarded with `pytest.importorskip("fitz")`.
- **Budget:** +27 lines, total now 678 / 1000.
- Pairs with #5 (CI) — this is the test that makes CI worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru)_