### PR TITLE
check: catch letter/word mismatch and bad image dimensions (#6)

### DIFF
--- a/lettercards/deck.py
+++ b/lettercards/deck.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
+from PIL import Image
+
 STATUSES = ("idea", "active", "retired")
 
 
@@ -107,11 +109,23 @@ def check_deck(deck_dir: Path) -> tuple[list[Card], list[str]]:
             problems.append(f"{where}: letter must be a single letter, got '{card.letter}'")
         if card.status not in STATUSES:
             problems.append(f"{where}: unknown status '{card.status}'")
+        if len(card.letter) == 1 and card.word and card.word[0].lower() != card.letter \
+                and not card.notes:
+            problems.append(f"{where}: word starts with '{card.word[0].lower()}', "
+                            f"not letter '{card.letter}' (add a note to allow an exception)")
         if card.status == "active":
             if not card.image:
                 problems.append(f"{where}: active card has no image (should it be an idea?)")
-            elif resolve_image(card, deck_dir) is None:
-                problems.append(f"{where}: image '{card.image}' not found in deck or starter images")
+            else:
+                image_path = resolve_image(card, deck_dir)
+                if image_path is None:
+                    problems.append(f"{where}: image '{card.image}' not found in deck or starter images")
+                else:
+                    with Image.open(image_path) as img:
+                        w, h = img.size
+                    if w != h or min(w, h) < 400:
+                        problems.append(f"{where}: image '{card.image}' is {w}x{h}px, "
+                                        f"must be square and at least 400x400")
         key = (card.word.lower(), card.language)
         if card.word and key in seen:
             problems.append(f"{where}: duplicate of line {seen[key]}")

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -60,6 +60,30 @@ def test_check_reports_problems(deck):
     assert "bogus" in text
 
 
+def test_check_flags_letter_word_mismatch(deck):
+    (deck / "deck.csv").write_text(
+        "letter,word,image,language,status,notes\n"
+        "b,kat,zebra.png,nl,active,\n"                      # wrong: kat under b
+        "d,dolfijn,,nl,idea,\n"                             # wrong but noted -> allowed
+        "d,dolfijn2,,nl,idea,ij digraph exception\n",
+        encoding="utf-8")
+    _, problems = check_deck(deck)
+    text = "\n".join(problems)
+    assert "not letter 'b'" in text
+    assert "dolfijn" not in text  # noted exceptions are suppressed
+
+
+def test_check_flags_bad_image_dimensions(deck):
+    from PIL import Image
+    Image.new("RGB", (400, 300), "#3366AA").save(deck / "images" / "wide.png")
+    (deck / "deck.csv").write_text(
+        "letter,word,image,language,status,notes\n"
+        "w,wide,wide.png,nl,active,\n",
+        encoding="utf-8")
+    _, problems = check_deck(deck)
+    assert any("400x300" in p and "square" in p for p in problems)
+
+
 def test_starter_deck_is_valid():
     cards, problems = check_deck(starter_dir())
     assert problems == []


### PR DESCRIPTION
Closes #6.

Deck editing is deliberately raw CSV, so `lettercards check` is the only safety net. Two cheap additions to `check_deck()` in `deck.py`:

## 1. Letter/word-initial mismatch
`b,kat,...` currently renders silently with the wrong accent color and files under the wrong letter-family card. `check` now warns when `word[0] != letter`.

- **Escape hatch:** suppressed when the row has a `notes` value — the documented way to allow a legitimate exception (e.g. a future `ij`-digraph word). No note → it's flagged.
- Only runs once the letter is a valid single character, so it doesn't double-report on the existing "letter must be a single letter" error.

## 2. Image technical checks
SOURCES.md acceptance criterion #4 (square, ≥ 400×400) was enforced only by human diligence. For each active card with a resolvable image, `check` now opens it with Pillow and flags non-square or undersized files (e.g. `400x300px, must be square and at least 400x400`).

## Notes
- Both live in `check_deck()`; two new tests (`test_check_flags_letter_word_mismatch`, `test_check_flags_bad_image_dimensions`).
- All 34 starter images are 400×400, so `test_starter_deck_is_valid` still passes.
- Budget: 716 / 1000 lines. Feeds the 2.0.0 exit criteria in #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru)_