### PR TITLE
Polish batch: friendly CLI errors, dead code, provenance, anchor freeze (#14)

### DIFF
--- a/lettercards/cli.py
+++ b/lettercards/cli.py
@@ -88,7 +88,13 @@ def main(argv=None) -> int:
     p_photo.set_defaults(func=_photo)
 
     args = parser.parse_args(argv)
-    return args.func(args)
+    try:
+        return args.func(args)
+    except OSError as e:
+        # Deck/image not found, unreadable file, wrong format (e.g. heic) —
+        # the commands know what they need, so show one line, not a traceback.
+        print(f"error: {e}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/lettercards/deck.py
+++ b/lettercards/deck.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
-COLUMNS = ("letter", "word", "image", "language", "status", "notes")
 STATUSES = ("idea", "active", "retired")
 
 

--- a/lettercards/starter/images/SOURCES.md
+++ b/lettercards/starter/images/SOURCES.md
@@ -69,6 +69,9 @@ Proven July 2026 (the 16-image batch below, ~$0.40 total):
   prompt above as `prompt`, and `image[]=` zebra.png, beer.png, appel.png. The
   response carries base64 PNG in `data[0].b64_json`. Escalate to `gpt-image-1.5`
   only if mini can't hold the style (~$0.02 vs ~$0.06 per image, July 2026 prices).
+- **Frozen anchors:** the reference images attached to every generation are permanently
+  `zebra.png`, `beer.png`, `appel.png` — never a later image that was itself generated from
+  them, so the style can't drift copy-of-a-copy across future batches.
 - **Guardrails:** keep a per-session image cap (~25) and print a cost estimate per
   call; the platform key is prepaid with auto-recharge off, so the credit balance
   is the hard ceiling. Expect ~1.3 generations per accepted image (text sneaking
@@ -86,28 +89,28 @@ Proven July 2026 (the 16-image batch below, ~$0.40 total):
 
 | Preview | Name | Source | Date | Prompt |
 |:-------:|------|--------|------|--------|
-| ![appel](appel.png) | appel | ChatGPT/DALL-E | 2026-03-19 | |
-| ![auto](auto.png) | auto | ChatGPT/DALL-E | 2026-03-19 | |
+| ![appel](appel.png) | appel | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![auto](auto.png) | auto | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
 | ![bad](bad.png) | bad | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a bathtub with a few soap bubbles" (refs: zebra, beer, appel) |
 | ![bal](bal.png) | bal | ChatGPT/DALL-E | 2026-03-19 | Create a 3x1 grid of cute, simple, child-friendly illustration style similar to Dutch children's books like Nijntje (Miffy) or Dikkie Dik. Soft rounded shapes, warm colors, gentle outlines, cream/beige background. The style should be appealing to toddlers (age 2). The 3 items to draw (left to right, top to bottom): banaan, beer, bal. Each item should be in its own cell with a cream/beige background. Keep items centered and recognizable for a toddler. |
 | ![banaan](banaan.png) | banaan | ChatGPT/DALL-E | 2026-03-19 | Create a 3x1 grid of cute, simple, child-friendly illustration style similar to Dutch children's books like Nijntje (Miffy) or Dikkie Dik. Soft rounded shapes, warm colors, gentle outlines, cream/beige background. The style should be appealing to toddlers (age 2). The 3 items to draw (left to right, top to bottom): banaan, beer, bal. Each item should be in its own cell with a cream/beige background. Keep items centered and recognizable for a toddler. |
 | ![beer](beer.png) | beer | ChatGPT/DALL-E | 2026-03-19 | Create a 3x1 grid of cute, simple, child-friendly illustration style similar to Dutch children's books like Nijntje (Miffy) or Dikkie Dik. Soft rounded shapes, warm colors, gentle outlines, cream/beige background. The style should be appealing to toddlers (age 2). The 3 items to draw (left to right, top to bottom): banaan, beer, bal. Each item should be in its own cell with a cream/beige background. Keep items centered and recognizable for a toddler. |
 | ![boom](boom.png) | boom | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a leafy green tree" (refs: zebra, beer, appel) |
-| ![deur](deur.png) | deur | ChatGPT/DALL-E | 2026-03-19 | |
-| ![draak](draak.png) | draak | ChatGPT/DALL-E | 2026-03-19 | |
-| ![druif](druif.png) | druif | ChatGPT/DALL-E | 2026-03-19 | |
-| ![eend](eend.png) | eend | ChatGPT/DALL-E | 2026-03-19 | |
-| ![fiets](fiets.png) | fiets | ChatGPT/DALL-E | 2026-03-19 | |
+| ![deur](deur.png) | deur | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![draak](draak.png) | draak | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![druif](druif.png) | druif | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![eend](eend.png) | eend | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![fiets](fiets.png) | fiets | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
 | ![hand](hand.png) | hand | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "an open child's hand, palm forward" (refs: zebra, beer, appel) |
 | ![huis](huis.png) | huis | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a simple house with a red roof" (refs: zebra, beer, appel) |
 | ![jas](jas.png) | jas | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a child's winter coat" (refs: zebra, beer, appel) |
-| ![kat](kat.png) | kat | ChatGPT/DALL-E | 2026-03-18 | |
-| ![koe](koe.png) | koe | ChatGPT/DALL-E | 2026-03-18 | |
-| ![leeuw](leeuw.png) | leeuw | ChatGPT/DALL-E | 2026-03-18 | |
+| ![kat](kat.png) | kat | ChatGPT/DALL-E | 2026-03-18 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![koe](koe.png) | koe | ChatGPT/DALL-E | 2026-03-18 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![leeuw](leeuw.png) | leeuw | ChatGPT/DALL-E | 2026-03-18 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
 | ![melk](melk.png) | melk | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a drinking glass of white milk next to an oat-milk carton with a blank label and glass pictogram (no text)" (refs: zebra, beer, appel) |
 | ![muis](muis.png) | muis | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a little grey mouse" (refs: zebra, beer, appel) |
 | ![neus](neus.png) | neus | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a simple human nose" (refs: zebra, beer, appel) |
-| ![olifant](olifant.png) | olifant | ChatGPT/DALL-E | 2026-03-18 | |
+| ![olifant](olifant.png) | olifant | ChatGPT/DALL-E | 2026-03-18 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
 | ![oog](oog.png) | oog | ChatGPT/DALL-E | 2026-03-22 | Create a cute, simple, child-friendly illustration style similar to Dutch children's books like Nijntje (Miffy) or Dikkie Dik. Soft rounded shapes, warm colors, gentle outlines, pure white (#FFFFFF) background. The style should be appealing to toddlers (age 2). No text, labels, or captions in the image. Draw: oog. Make it centered on a cream/beige background, simple and recognizable for a toddler. |
 | ![peer](peer.png) | peer | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a green-yellow pear with a leaf" (refs: zebra, beer, appel) |
 | ![regen](regen.png) | regen | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a rain cloud with falling raindrops" (refs: zebra, beer, appel) |
@@ -117,6 +120,6 @@ Proven July 2026 (the 16-image batch below, ~$0.40 total):
 | ![tand](tand.png) | tand | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a single white tooth" (refs: zebra, beer, appel) |
 | ![vis](vis.png) | vis | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a chubby orange fish" (refs: zebra, beer, appel) |
 | ![vlinder](vlinder.png) | vlinder | gpt-image-1-mini | 2026-07-05 | master prompt, subject: "a colorful butterfly" (refs: zebra, beer, appel) |
-| ![water](water.png) | water | ChatGPT/DALL-E | 2026-03-19 | |
-| ![zebra](zebra.png) | zebra | ChatGPT/DALL-E | 2026-03-18 | |
-| ![zon](zon.png) | zon | ChatGPT/DALL-E | 2026-03-19 | |
+| ![water](water.png) | water | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![zebra](zebra.png) | zebra | ChatGPT/DALL-E | 2026-03-18 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |
+| ![zon](zon.png) | zon | ChatGPT/DALL-E | 2026-03-19 | _prompt lost — regenerate from the master prompt if this image ever needs fixing_ |

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -124,6 +124,13 @@ def test_rendered_page_actually_shows_a_card(tmp_path):
     assert corner[0] - band[0] > 20                      # band tint differs from background
 
 
+def test_cli_render_missing_deck_is_friendly(tmp_path, capsys):
+    """A missing deck exits 1 with one error line, not a raw traceback."""
+    rc = main(["render", str(tmp_path / "nope"), "-o", str(tmp_path / "x.pdf")])
+    assert rc == 1
+    assert "error:" in capsys.readouterr().err
+
+
 def test_cli_photo_crops_square(tmp_path):
     from PIL import Image
     src = tmp_path / "portrait.jpg"


### PR DESCRIPTION
Closes #14. The four batched items from the July 2026 critique round:

## Friendly CLI errors instead of tracebacks
`main()` now wraps the command dispatch in `try/except OSError`. A missing deck (`render /nonexistent` → `FileNotFoundError`) or an unreadable/unsupported image (`photo pic.heic` → PIL internals) prints a single `error: ...` line to stderr and exits 1, instead of a raw traceback. `OSError` covers both `FileNotFoundError` and PIL's `UnidentifiedImageError`. Test: `test_cli_render_missing_deck_is_friendly`.

## Delete the dead `COLUMNS` constant
Removed from `deck.py` — declared, never read.

## Backfill March provenance honestly
14 table rows in `SOURCES.md` had empty prompt cells (the `ChatGPT/DALL-E` March incumbents). Each now reads *prompt lost — regenerate from the master prompt if this image ever needs fixing*. Rows with a real recorded prompt (bal, banaan, beer, oog, all the July gpt-image rows) are untouched. Acceptance criterion #5 ("Recorded") is no longer graded on a curve for incumbents.

## Freeze the style anchors
One line added to the generation recipe: reference images attached to generations are permanently `zebra.png` / `beer.png` / `appel.png` — never a later image that was itself generated from them — to prevent generational copy-of-a-copy style drift.

## Notes
- CLI + dead-code changes touch engine error paths only; docs items would go straight to `main`, bundled here to keep the batch atomic.
- Budget: 690 / 1000 lines. All 13 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru)_