### PR TITLE
render: --rect uniform cards + --cut-lines guides for straight cuts (#15)

### DIFF
--- a/lettercards/cli.py
+++ b/lettercards/cli.py
@@ -21,7 +21,8 @@ def _render(args) -> int:
         return 1
 
     output = Path(args.output)
-    stats = render_pdf(selected, deck_dir, output)
+    stats = render_pdf(selected, deck_dir, output,
+                       rounded=not args.rect, cut_lines=args.cut_lines)
     print(f"✓ {output} — {stats['cards']} cards "
           f"({stats['picture_cards']} picture + {stats['letter_cards']} letter), "
           f"{stats['pages']} page(s)")
@@ -73,6 +74,10 @@ def main(argv=None) -> int:
     p_render.add_argument("--letters", help="only these letters, comma-separated (a,d,o)")
     p_render.add_argument("--cards", help="only these words, comma-separated (zebra,kat)")
     p_render.add_argument("-o", "--output", default="cards.pdf", help="output PDF path")
+    p_render.add_argument("--rect", action="store_true",
+                          help="square-cornered cards, for clean straight cuts")
+    p_render.add_argument("--cut-lines", action="store_true",
+                          help="dashed cutting guides along card edges (off by default)")
     p_render.set_defaults(func=_render)
 
     p_check = sub.add_parser("check", help="validate a deck and summarize its state")

--- a/lettercards/layout.py
+++ b/lettercards/layout.py
@@ -108,11 +108,28 @@ def _tint(color, alpha):
     return Color(color.red, color.green, color.blue, alpha=alpha)
 
 
-def _card_base(c, x, y, fill):
+def _card_base(c, x, y, fill, radius=CORNER_R):
     c.setStrokeColor(BORDER)
     c.setLineWidth(0.5)
     c.setFillColor(fill)
-    c.roundRect(x, y, CARD_W, CARD_H, CORNER_R, fill=1, stroke=1)
+    c.roundRect(x, y, CARD_W, CARD_H, radius, fill=1, stroke=1)
+
+
+def draw_cut_lines(c):
+    """Dashed guides along every card edge, for straight-cutting a full sheet."""
+    c.saveState()
+    c.setStrokeColor(BORDER)
+    c.setLineWidth(0.4)
+    c.setDash(2, 3)
+    xs = sorted({MARGIN_X + col * (CARD_W + SPACING_X) + dx
+                 for col in range(COLS) for dx in (0, CARD_W)})
+    ys = sorted({PAGE_H - MARGIN_Y - (row + 1) * CARD_H - row * SPACING_Y + dy
+                 for row in range(ROWS) for dy in (0, CARD_H)})
+    for x in xs:
+        c.line(x, ys[0], x, ys[-1])
+    for y in ys:
+        c.line(xs[0], y, xs[-1], y)
+    c.restoreState()
 
 
 def _draw_image(c, path, ax, ay, aw, ah):
@@ -140,16 +157,16 @@ def _language_pill(c, x, y, language):
     c.drawString(px + (w - tw) / 2, py + 1.2 * mm, language)
 
 
-def draw_picture_card(c, x, y, word, image_path, letter, language):
+def draw_picture_card(c, x, y, word, image_path, letter, language, radius=CORNER_R):
     """Image on cream, word on an accent-tinted band, language pill."""
     register_fonts()
     accent = LETTER_COLORS.get(letter, HIGHLIGHT)
-    _card_base(c, x, y, BG_CARD)
+    _card_base(c, x, y, BG_CARD, radius)
 
     band_h = CARD_H * 0.24
     c.setFillColor(_tint(accent, BAND_ALPHA))
-    c.roundRect(x, y, CARD_W, band_h, CORNER_R, fill=1, stroke=0)
-    c.rect(x, y + band_h - CORNER_R, CARD_W, CORNER_R, fill=1, stroke=0)
+    c.roundRect(x, y, CARD_W, band_h, radius, fill=1, stroke=0)
+    c.rect(x, y + band_h - radius, CARD_W, radius, fill=1, stroke=0)
 
     _draw_image(c, image_path, x + 4 * mm, y + CARD_H * 0.27,
                 CARD_W - 8 * mm, CARD_H * 0.68)
@@ -171,13 +188,13 @@ def draw_picture_card(c, x, y, word, image_path, letter, language):
     _language_pill(c, x, y, language)
 
 
-def draw_letter_card(c, x, y, letter):
+def draw_letter_card(c, x, y, letter, radius=CORNER_R):
     """Letter family: big canonical lowercase + specimen row of other shapes."""
     register_fonts()
     accent = LETTER_COLORS.get(letter, HIGHLIGHT)
-    _card_base(c, x, y, BG_CARD)
+    _card_base(c, x, y, BG_CARD, radius)
     c.setFillColor(_tint(accent, LETTER_BG_ALPHA))
-    c.roundRect(x, y, CARD_W, CARD_H, CORNER_R, fill=1, stroke=0)
+    c.roundRect(x, y, CARD_W, CARD_H, radius, fill=1, stroke=0)
 
     size = 110
     c.setFont(PRIMARY, size)

--- a/lettercards/render.py
+++ b/lettercards/render.py
@@ -9,11 +9,14 @@ from . import layout
 from .deck import Card, resolve_image
 
 
-def render_pdf(cards: list[Card], deck_dir: Path, output: Path) -> dict:
+def render_pdf(cards: list[Card], deck_dir: Path, output: Path,
+               rounded: bool = True, cut_lines: bool = False) -> dict:
     """Render picture + letter cards to an A4 PDF. Returns stats.
 
     Each word gets a picture card; each distinct letter additionally
-    gets one letter-family card.
+    gets one letter-family card. ``rounded=False`` draws square-cornered
+    cards and ``cut_lines=True`` adds dashed cutting guides — both for
+    straight-cutting a sheet with a guillotine.
     """
     c = canvas.Canvas(str(output), pagesize=A4)
     c.setTitle("Letterkaarten")
@@ -27,18 +30,22 @@ def render_pdf(cards: list[Card], deck_dir: Path, output: Path) -> dict:
             items.append(("letter", card))
 
     per_page = layout.COLS * layout.ROWS
+    radius = layout.CORNER_R if rounded else 0
     for i, (kind, card) in enumerate(items):
-        if i and i % per_page == 0:
-            c.showPage()
+        if i % per_page == 0:
+            if i:
+                c.showPage()
+            if cut_lines:
+                layout.draw_cut_lines(c)
         col, row = i % per_page % layout.COLS, i % per_page // layout.COLS
         x = layout.MARGIN_X + col * (layout.CARD_W + layout.SPACING_X)
         y = layout.PAGE_H - layout.MARGIN_Y - (row + 1) * layout.CARD_H - row * layout.SPACING_Y
         if kind == "picture":
             layout.draw_picture_card(c, x, y, card.word,
                                      resolve_image(card, deck_dir),
-                                     card.letter, card.language)
+                                     card.letter, card.language, radius)
         else:
-            layout.draw_letter_card(c, x, y, card.letter)
+            layout.draw_letter_card(c, x, y, card.letter, radius)
 
     c.save()
     return {

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -131,6 +131,18 @@ def test_cli_render_missing_deck_is_friendly(tmp_path, capsys):
     assert "error:" in capsys.readouterr().err
 
 
+def test_render_rect_and_cut_lines(tmp_path):
+    """--rect and --cut-lines both render; cut guides add vector paths."""
+    fitz = pytest.importorskip("fitz")
+    plain, cut = tmp_path / "plain.pdf", tmp_path / "cut.pdf"
+    assert main(["render", "starter", "--cards", "zebra", "-o", str(plain)]) == 0
+    assert main(["render", "starter", "--cards", "zebra",
+                 "--rect", "--cut-lines", "-o", str(cut)]) == 0
+    n_plain = len(fitz.open(plain)[0].get_drawings())
+    n_cut = len(fitz.open(cut)[0].get_drawings())
+    assert n_cut > n_plain  # dashed guides are extra strokes on the page
+
+
 def test_cli_photo_crops_square(tmp_path):
     from PIL import Image
     src = tmp_path / "portrait.jpg"


### PR DESCRIPTION
Closes #15.

Hand-cutting a rendered sheet is fiddly: each card is a rounded rectangle, so a straight cut across the 3×3 grid clips the corners. The grid spacing is already uniform — it's the card *shape*, not the layout, that fights a guillotine.

## Two flags on `render` (both default off — standard output is unchanged)

- **`--rect`** — square-cornered cards. The corner radius threads through as `0`, so the accent band and letter-family background square off too. One straight-cut grid now separates the whole sheet without clipping.
- **`--cut-lines`** — dashed guides along every card edge. Off by default, so the default output stays clean for anyone cutting freehand.

## Implementation
- `render_pdf(..., rounded=True, cut_lines=False)`; `radius = CORNER_R if rounded else 0` threaded into `draw_picture_card` / `draw_letter_card` / `_card_base` (reportlab's `roundRect(..., 0, ...)` draws a clean square rect, so no branching).
- New `layout.draw_cut_lines(c)` draws the dashed edge grid once per page.
- No layout/spacing change — card size and gutters are untouched.

## Verification
- `--rect` genuinely fills the square corner: the extreme card corner pixel goes from `(255,255,255)` bare page (rounded) to card cream `(251,244,235)` (rect).
- `--cut-lines` adds vector paths (page drawings 20 → 38). New test `test_render_rect_and_cut_lines`.
- Budget: 719 / 1000. All 13 tests pass. Preview of `--rect --cut-lines` attached in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru)_