### PR TITLE
Design/print fixes: legible o/e/i accents, contrast test, solid tints, 800px (#12)

### DIFF
--- a/lettercards/layout.py
+++ b/lettercards/layout.py
@@ -39,15 +39,16 @@ BAND_ALPHA = 0.14
 LETTER_BG_ALPHA = 0.12
 
 # Vowels get warm hues (each unique), consonants cool ones — a soft
-# Montessori-style vowel/consonant cue. Two invariants (tested): alphabet
-# neighbors never share a color, and every color is dark enough to work
-# both as word text on cream and as a ~14% background tint.
+# Montessori-style vowel/consonant cue. Three invariants (tested): alphabet
+# neighbors never share a color; warm iff vowel; and every color clears
+# WCAG 3:1 contrast on the cream card, so the highlighted first letter — the
+# phonics cue — stays legible as word text.
 LETTER_COLORS = {
     'a': HexColor("#E63946"), 'b': HexColor("#457B9D"), 'c': HexColor("#6A4C93"),
-    'd': HexColor("#2A9D8F"), 'e': HexColor("#F4A261"), 'f': HexColor("#6A4C93"),
-    'g': HexColor("#1D3557"), 'h': HexColor("#2A9D8F"), 'i': HexColor("#E76F51"),
+    'd': HexColor("#2A9D8F"), 'e': HexColor("#D8680F"), 'f': HexColor("#6A4C93"),
+    'g': HexColor("#1D3557"), 'h': HexColor("#2A9D8F"), 'i': HexColor("#E45C3B"),
     'j': HexColor("#3D8EB9"), 'k': HexColor("#6A4C93"), 'l': HexColor("#2A9D8F"),
-    'm': HexColor("#264653"), 'n': HexColor("#457B9D"), 'o': HexColor("#E9C46A"),
+    'm': HexColor("#264653"), 'n': HexColor("#457B9D"), 'o': HexColor("#AB8119"),
     'p': HexColor("#6A4C93"), 'q': HexColor("#3D8EB9"), 'r': HexColor("#1D3557"),
     's': HexColor("#2A9D8F"), 't': HexColor("#457B9D"), 'u': HexColor("#9C6644"),
     'v': HexColor("#457B9D"), 'w': HexColor("#1D3557"), 'x': HexColor("#6A4C93"),
@@ -105,7 +106,13 @@ def register_fonts():
 
 
 def _tint(color, alpha):
-    return Color(color.red, color.green, color.blue, alpha=alpha)
+    """An alpha tint of ``color`` precomputed over the cream card as an opaque
+    color. Print-shop RIPs flatten live PDF transparency unpredictably, so we
+    never emit it: composite here instead. Backdrop is the card cream, which is
+    exactly what sits behind the band and letter background."""
+    return Color(*(bg + (ch - bg) * alpha for ch, bg in (
+        (color.red, BG_CARD.red), (color.green, BG_CARD.green),
+        (color.blue, BG_CARD.blue))))
 
 
 def _card_base(c, x, y, fill):
@@ -116,7 +123,6 @@ def _card_base(c, x, y, fill):
 
 
 def _draw_image(c, path, ax, ay, aw, ah):
-    c.setFillAlpha(1)  # clear any alpha left in the graphics state
     with Image.open(path) as img:
         iw, ih = img.size
     aspect = iw / ih

--- a/lettercards/photos.py
+++ b/lettercards/photos.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from PIL import Image, ImageOps
 
 PHOTO_SIZE = 800      # card image area is ~5.2cm; 800px leaves 300dpi headroom
-PICTOGRAM_SIZE = 400  # matches the starter set
+PICTOGRAM_SIZE = 800  # ~300dpi in the image area; existing 400px starter images
+                      # are upgraded opportunistically when regenerated
 CARD_CREAM = (255, 248, 240)
 
 

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -97,6 +97,22 @@ def test_letter_colors_vowel_consonant_split():
         assert LETTER_COLORS[a] != LETTER_COLORS[b], f"{a}/{b} share a color"
 
 
+def test_letter_colors_meet_contrast_on_cream():
+    """Every accent clears WCAG 3:1 on the cream card, so the highlighted
+    first letter — the phonics cue — stays legible (guards o/e/i regressions)."""
+    from lettercards.layout import LETTER_COLORS, BG_CARD
+
+    def rel_lum(c):
+        ch = [v / 12.92 if v <= 0.03928 else ((v + 0.055) / 1.055) ** 2.4
+              for v in (c.red, c.green, c.blue)]
+        return 0.2126 * ch[0] + 0.7152 * ch[1] + 0.0722 * ch[2]
+
+    cream = rel_lum(BG_CARD)
+    for letter, color in LETTER_COLORS.items():
+        lo, hi = sorted((cream, rel_lum(color)))
+        assert (hi + 0.05) / (lo + 0.05) >= 3.0, f"{letter} fails 3:1 on cream"
+
+
 def test_rendered_page_actually_shows_a_card(tmp_path):
     """Guard the central rule: a rendered page contains card ink and words,
     not just a valid %PDF- header. Catches white-on-white and missing draws."""
@@ -150,6 +166,6 @@ def test_cli_photo_pictogram_flattens_background(tmp_path):
     out = tmp_path / "vis.png"
     assert main(["photo", str(src), str(out), "--pictogram"]) == 0
     with Image.open(out) as result:
-        assert result.size == (400, 400)
+        assert result.size == (800, 800)                     # PICTOGRAM_SIZE, ~300dpi
         assert result.getpixel((2, 2)) == (255, 248, 240)   # background now card cream
-        assert result.getpixel((200, 200)) != (255, 248, 240)  # subject untouched
+        assert result.getpixel((400, 400)) != (255, 248, 240)  # subject untouched


### PR DESCRIPTION
Closes #12. All four print-quality items, in one PR since they're all rendered-output changes.

## 1. Legible vowel accents
The highlighted first letter *is* the phonics cue, and three vowels failed WCAG contrast on the cream card:

| letter | before | contrast | after | contrast |
|---|---|---|---|---|
| o | #E9C46A | **1.59:1** | #AB8119 | 3.39:1 |
| e | #F4A261 | **1.96:1** | #D8680F | 3.38:1 |
| i | #E76F51 | **2.94:1** | #E45C3B | 3.38:1 |

The issue named o and e; measuring the whole palette surfaced **i** failing too (2.94:1), so I fixed all three. New hues keep vowel-warm/consonant-cool, alphabet-neighbor distinctness, and mutual vowel distinctness (all verified).

## 2. Real contrast test
`test_letter_colors_meet_contrast_on_cream` asserts every accent clears 3:1 (WCAG relative luminance vs `#FFF8F0`). The old comment *claimed* this invariant was tested; now it actually is, so it can't silently regress.

## 3. Solid tints instead of alpha
Band, letter background, and pill used PDF transparency (`Color(alpha=…)`); print-shop RIPs flatten that unpredictably. `_tint()` now precomputes the tint over the cream and returns an **opaque** color — pixel-identical for the band and letter background (which sit on cream). The `_draw_image` `setFillAlpha(1)` workaround is gone; no live transparency is emitted anywhere.

## 4. 800px pictograms
`PICTOGRAM_SIZE` 400 → 800 (~300 dpi in the ~52 mm image area; 400px was ~195 dpi). Existing starter images stay 400px and upgrade opportunistically when regenerated. `test_cli_photo_pictogram_flattens_background` updated to 800.

## Verification
- All 14 tests pass (incl. new contrast test + the golden render test from #13). Budget 713/1000.
- Rendered `e`/`o` cards attached in the session — the accents are now clearly readable where they were washed out before.
- The contrast fix intentionally changes existing printed decks' o/e/i cards; that's the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMjjUee7SVCZK7qj44ecru)_