### PR TITLE
Single-source the version and guard release tags against drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']  # release tags, checked against __version__ below
   pull_request:
   schedule:
     - cron: '0 6 * * 1'  # weekly: catch reportlab/Pillow rot while the repo sits idle
@@ -30,3 +31,21 @@ jobs:
           total=$(wc -l lettercards/*.py tests/*.py | tail -1 | awk '{print $1}')
           echo "Python lines: $total / 1000"
           test "$total" -le 1000
+
+  version-tag-match:
+    # A release tag must point at a commit whose __version__ matches it —
+    # git won't enforce that coupling, so fail the tag push if it drifts.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -e .
+      - name: Tag must match __version__
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          got="$(python -c 'import lettercards; print(lettercards.__version__)')"
+          echo "tag: $tag / __version__: $got"
+          test "$tag" = "$got"

--- a/lettercards/__init__.py
+++ b/lettercards/__init__.py
@@ -1,3 +1,3 @@
 """lettercards — printable letter-learning cards for toddlers."""
 
-__version__ = "2.0.0a1"
+__version__ = "2.0.0a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lettercards"
-version = "2.0.0a2"
+dynamic = ["version"]
 description = "Printable A4 letter-learning cards for toddlers"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -25,6 +25,9 @@ Repository = "https://github.com/jvspl/lettercards"
 
 [tool.setuptools]
 packages = ["lettercards"]
+
+[tool.setuptools.dynamic]
+version = { attr = "lettercards.__version__" }
 
 [tool.setuptools.package-data]
 lettercards = ["starter/deck.csv", "starter/images/*.png", "starter/images/SOURCES.md",

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -183,6 +183,18 @@ def test_render_rect_and_cut_lines(tmp_path):
     assert n_cut > n_plain  # dashed guides are extra strokes on the page
 
 
+def test_version_is_single_sourced(capsys):
+    """--version, package metadata, and __version__ come from one place, so a
+    downstream git-install can trust the reported version (guards a1/a2 drift)."""
+    from importlib.metadata import version
+    import lettercards
+
+    with pytest.raises(SystemExit):        # argparse --version exits 0 after printing
+        main(["--version"])
+    printed = capsys.readouterr().out.strip()
+    assert printed == lettercards.__version__ == version("lettercards")
+
+
 def test_cli_photo_crops_square(tmp_path):
     from PIL import Image
     src = tmp_path / "portrait.jpg"


### PR DESCRIPTION
Addresses the version-drift parts of #7 so a downstream git-installed deck repo can trust what `lettercards --version` reports.

## What changed

**1. Single-source the package version.** `lettercards --version` reported `2.0.0a1` (from `__init__.py`) while package metadata said `2.0.0a2` (from `pyproject.toml`) — a version that disagrees with itself. `__init__.__version__` is now the one source; `pyproject` derives its version via `[tool.setuptools.dynamic]`. The CLI, `importlib.metadata`, and the module attribute can no longer drift apart, and a test asserts all three agree (runs in CI on every PR).

**2. Guard release tags in CI.** Git doesn't enforce that tag `vX.Y.Z` points at a commit whose `__version__` is `X.Y.Z` — that coupling was held together by hand. A tag-triggered job (`push: tags: ['v*']`) installs the package and fails the tag push if the tag doesn't equal `lettercards.__version__`, so a forgotten bump can't ship a mislabeled release.

## Enforcement picture after this PR

| Drift risk | Enforcement |
|---|---|
| `__init__` ↔ metadata ↔ `--version` disagree | Structurally impossible + CI test on every PR |
| Tag `vX.Y.Z` points at a commit with the wrong `__version__` | New tag-match job fails the push |
| Whether/how much to bump (patch/minor/major) | Human call — convention, not a gate |

## Deliberately out of scope

- Version stays at `2.0.0a2` — the bump to `2.0.0` is gated on #7's exit criteria (alphabet coverage is the remaining blocker) and belongs in the same commit as that content work.
- Starter-deck drift-signal (ask #3) and changelog (ask #2) are resolved on the issue thread as won't-do-now: a single consumer + pinning the family repo to the `v2.0.0` tag makes a drift-detector redundant, and the changelog waits until v2 is final.

## Testing

`python -m pytest -q` → 18 passed. Line budget 804/1000. Tag-match logic simulated locally: `v2.0.0a2` matches and passes; a premature `v2.0.0` fails as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8N1kkbwHEp9kNpyPczFYQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8N1kkbwHEp9kNpyPczFYQ)_