### PR TITLE
Using the cards: minimal v2 how-to page + README section (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,23 +35,13 @@ k,kasteel,,nl,idea,needs image
 
 ## Using the cards
 
-Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive toddlers. The deck grows with the child; don't use all of it at once. Words and letters can grow together from the very start: a child who loves a picture card can just as happily notice the colored letter on it, often well into the second year. You don't have to wait for a "right age" — recognising letters isn't gated behind one; it's blending them into words that usually comes later. So the ages below are the roughest of guides. Follow the child, not the number.
-
-The stages overlap and are led by the child's interest — they are not gates to clear in order:
-
-- **Naming — from ~1:** As soon as the child points at and names pictures — often early in the second year — start here. Show a card, say the word, let the child point and name. A handful at a time, led by the child's interest. The printed word is for you; the colored first letter is right there for the child to notice whenever she's curious about it.
-- **First sounds — from ~2:** Sound games with the picture cards: “b-b-b… bal!” The colored first letter shows what to stress. Sort cards by first sound — all cards for a letter share their band color.
-- **Letters — child-led, alongside words:** Bring in the letter-family cards and match picture cards to their letter. Many children are keen on letters as young toddlers — if she's already pointing at them, follow her lead rather than holding the cards back for a later age.
-- **First words — once a few sounds are known:** When the child knows a handful of letter sounds, start blending them: say the sounds close together and let them melt into the word — “mmm-aaa-nnn… man”. Slide a finger under the letters as you go. Short, sound-it-out words first, with the picture there to confirm the answer. This is the bridge from single letters to reading.
-
-### Two things about letters
-
-- **A letter wears different clothes:** The same letter looks different as a capital and a small letter, in print and in handwriting — A and a are one letter. Children learn this by seeing it, not by being told: point out the same letter in its many forms, on the card, on a sign, in a name. The specimen row on each letter-family card is built for exactly this — one letter, different clothes.
-- **A letter can make more than one sound:** Some letters aren't loyal to one sound. Vowels come short and long (the a in “appel” versus “maan”); a c can sound like a k or an s. Teach the sound in the card's word first — one letter, one sound — and mention the others only later, as “this one can also say…”. Don't crowd the first sound with its exceptions.
+Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive toddlers. The deck grows with the child; don't use all of it at once — show a handful of cards at a time, led by the child's interest.
 
 Say letter sounds, not names — “mmm”, not “em”. The word list is curated for this: the first letter is the first sound.
 
-The same guidance prints as the final page(s) of a full `lettercards render`, so it travels with the deck. Filtered reprints (`--letters`/`--cards`) skip it; `--no-howto` omits it from a full render too.
+The same guidance prints as the final page of a full `lettercards render`, so it travels with the deck. Filtered reprints (`--letters`/`--cards`) skip it; `--no-howto` omits it from a full render too.
+
+> The staged letter-learning progression (ages, voices, blending) is deliberately **not** here — it's the v3 pedagogy, tracked in [#26](https://github.com/jvspl/lettercards/issues/26). v2 keeps this page small and practical.
 
 ## Project rules
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ k,kasteel,,nl,idea,needs image
 
 ## Using the cards
 
-Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive toddlers. The deck grows with the child; don't use all of it at once — show a handful of cards at a time, led by the child's interest.
+Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive toddlers.
 
-Say letter sounds, not names — “mmm”, not “em”. The word list is curated for this: the first letter is the first sound.
+The rest is what to do once you have the deck in hand, and it prints as the final page so it travels with the cards:
 
-The same guidance prints as the final page of a full `lettercards render`, so it travels with the deck. Filtered reprints (`--letters`/`--cards`) skip it; `--no-howto` omits it from a full render too.
+The deck grows with the child — don't use all of it at once. Show a card, say the word, and let the child point and name it; a handful of cards at a time, led by the child's interest. Keep it playful, and stop before it becomes a drill.
+
+Say letter sounds, not names — “mmm”, not “em”. The colored first letter is that sound — the first sound of the word — and every card for a letter shares its band color, so the cards sort into families.
+
+Filtered reprints (`--letters`/`--cards`) skip the how-to page; `--no-howto` omits it from a full render too.
 
 > The staged letter-learning progression (ages, voices, blending) is deliberately **not** here — it's the v3 pedagogy, tracked in [#26](https://github.com/jvspl/lettercards/issues/26). v2 keeps this page small and practical.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ k,kasteel,,nl,idea,needs image
 
 `lettercards/starter/` is a complete, ready-to-print Dutch deck: 34 words with child-friendly pictograms (Nijntje-ish style), bundled with the package so `lettercards render starter` works anywhere after install. Image provenance and licensing are tracked in [lettercards/starter/images/SOURCES.md](lettercards/starter/images/SOURCES.md).
 
+## Using the cards
+
+Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive toddlers. The deck grows with the child; don't use all of it at once. The ages below are the roughest of guides: children vary enormously and many are keen on letters long before they're "supposed" to be — follow the child, not the number. Say letter sounds, not names — “mmm”, not “em”. The word list is curated for this: the first letter is the first sound.
+
+- **Naming from ~1:** As soon as the child points at and names pictures — often early in the second year — start here. Picture cards only; letter cards stay in the drawer. Show a card, say the word, let the child point and name. A handful of cards at a time, led by the child's interest. The printed word is for you, not them.
+- **First sounds from ~2:** Sound games with the picture cards: “b-b-b… bal!” The colored first letter shows what to stress. Sort cards by first sound — all cards for a letter share their band color.
+- **Letters child-led, often 2–5:** Bring in the letter-family cards; match picture cards to their letter. Plenty of children are fascinated by letters as toddlers — if she's already pointing at them, follow her lead. The specimen row is the same letter in different clothes.
+
+The same guidance prints as the final page of a full `lettercards render`, so it travels with the deck. Filtered reprints (`--letters`/`--cards`) skip it; `--no-howto` omits it from a full render too.
+
 ## Project rules
 
 - **Line budget: ≤ 1,000 lines of Python including tests.** A feature that threatens the budget gets questioned before the budget does.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,23 @@ k,kasteel,,nl,idea,needs image
 
 ## Using the cards
 
-Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive toddlers. The deck grows with the child; don't use all of it at once. The ages below are the roughest of guides: children vary enormously and many are keen on letters long before they're "supposed" to be — follow the child, not the number. Say letter sounds, not names — “mmm”, not “em”. The word list is curated for this: the first letter is the first sound.
+Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive toddlers. The deck grows with the child; don't use all of it at once. Words and letters can grow together from the very start: a child who loves a picture card can just as happily notice the colored letter on it, often well into the second year. You don't have to wait for a "right age" — recognising letters isn't gated behind one; it's blending them into words that usually comes later. So the ages below are the roughest of guides. Follow the child, not the number.
 
-- **Naming from ~1:** As soon as the child points at and names pictures — often early in the second year — start here. Picture cards only; letter cards stay in the drawer. Show a card, say the word, let the child point and name. A handful of cards at a time, led by the child's interest. The printed word is for you, not them.
-- **First sounds from ~2:** Sound games with the picture cards: “b-b-b… bal!” The colored first letter shows what to stress. Sort cards by first sound — all cards for a letter share their band color.
-- **Letters child-led, often 2–5:** Bring in the letter-family cards; match picture cards to their letter. Plenty of children are fascinated by letters as toddlers — if she's already pointing at them, follow her lead. The specimen row is the same letter in different clothes.
+The stages overlap and are led by the child's interest — they are not gates to clear in order:
 
-The same guidance prints as the final page of a full `lettercards render`, so it travels with the deck. Filtered reprints (`--letters`/`--cards`) skip it; `--no-howto` omits it from a full render too.
+- **Naming — from ~1:** As soon as the child points at and names pictures — often early in the second year — start here. Show a card, say the word, let the child point and name. A handful at a time, led by the child's interest. The printed word is for you; the colored first letter is right there for the child to notice whenever she's curious about it.
+- **First sounds — from ~2:** Sound games with the picture cards: “b-b-b… bal!” The colored first letter shows what to stress. Sort cards by first sound — all cards for a letter share their band color.
+- **Letters — child-led, alongside words:** Bring in the letter-family cards and match picture cards to their letter. Many children are keen on letters as young toddlers — if she's already pointing at them, follow her lead rather than holding the cards back for a later age.
+- **First words — once a few sounds are known:** When the child knows a handful of letter sounds, start blending them: say the sounds close together and let them melt into the word — “mmm-aaa-nnn… man”. Slide a finger under the letters as you go. Short, sound-it-out words first, with the picture there to confirm the answer. This is the bridge from single letters to reading.
+
+### Two things about letters
+
+- **A letter wears different clothes:** The same letter looks different as a capital and a small letter, in print and in handwriting — A and a are one letter. Children learn this by seeing it, not by being told: point out the same letter in its many forms, on the card, on a sign, in a name. The specimen row on each letter-family card is built for exactly this — one letter, different clothes.
+- **A letter can make more than one sound:** Some letters aren't loyal to one sound. Vowels come short and long (the a in “appel” versus “maan”); a c can sound like a k or an s. Teach the sound in the card's word first — one letter, one sound — and mention the others only later, as “this one can also say…”. Don't crowd the first sound with its exceptions.
+
+Say letter sounds, not names — “mmm”, not “em”. The word list is curated for this: the first letter is the first sound.
+
+The same guidance prints as the final page(s) of a full `lettercards render`, so it travels with the deck. Filtered reprints (`--letters`/`--cards`) skip it; `--no-howto` omits it from a full render too.
 
 ## Project rules
 

--- a/lettercards/cli.py
+++ b/lettercards/cli.py
@@ -21,7 +21,10 @@ def _render(args) -> int:
         return 1
 
     output = Path(args.output)
-    stats = render_pdf(selected, deck_dir, output)
+    # The how-to page rides along on a full deck render; skip it for filtered
+    # reprints (--letters/--cards) so a single-letter reprint stays clean.
+    include_howto = not args.no_howto and not (letters or words)
+    stats = render_pdf(selected, deck_dir, output, howto=include_howto)
     print(f"✓ {output} — {stats['cards']} cards "
           f"({stats['picture_cards']} picture + {stats['letter_cards']} letter), "
           f"{stats['pages']} page(s)")
@@ -73,6 +76,8 @@ def main(argv=None) -> int:
     p_render.add_argument("--letters", help="only these letters, comma-separated (a,d,o)")
     p_render.add_argument("--cards", help="only these words, comma-separated (zebra,kat)")
     p_render.add_argument("-o", "--output", default="cards.pdf", help="output PDF path")
+    p_render.add_argument("--no-howto", action="store_true",
+                          help="omit the parent how-to page from a full-deck render")
     p_render.set_defaults(func=_render)
 
     p_check = sub.add_parser("check", help="validate a deck and summarize its state")

--- a/lettercards/howto.py
+++ b/lettercards/howto.py
@@ -1,31 +1,57 @@
 """Shared 'Using the cards' guidance.
 
-Single source of truth: the final PDF how-to page is drawn from these
-strings, and a test asserts the README's "Using the cards" section mirrors
-them verbatim — so the printed guidance and the README can't drift.
+Single source of truth: the PDF how-to page is drawn from these strings, and a
+test asserts the README's "Using the cards" section mirrors them verbatim — so
+the printed guidance and the README can't drift.
 """
 
 TITLE = "Using the cards"
 
 INTRO = ("Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive "
-         "toddlers. The deck grows with the child; don't use all of it at once. The ages "
-         "below are the roughest of guides: children vary enormously and many are keen on "
-         "letters long before they're \"supposed\" to be — follow the child, not the number.")
+         "toddlers. The deck grows with the child; don't use all of it at once. Words and "
+         "letters can grow together from the very start: a child who loves a picture card "
+         "can just as happily notice the colored letter on it, often well into the second "
+         "year. You don't have to wait for a \"right age\" — recognising letters isn't "
+         "gated behind one; it's blending them into words that usually comes later. So the "
+         "ages below are the roughest of guides. Follow the child, not the number.")
 
-# (stage, indicative ages, what to do)
+# (stage, indicative ages, what to do). The stages overlap and are led by the
+# child's interest — they are not gates to clear in order.
 STAGES = [
     ("Naming", "from ~1",
      "As soon as the child points at and names pictures — often early in the second year — "
-     "start here. Picture cards only; letter cards stay in the drawer. Show a card, say the "
-     "word, let the child point and name. A handful of cards at a time, led by the child's "
-     "interest. The printed word is for you, not them."),
+     "start here. Show a card, say the word, let the child point and name. A handful at a "
+     "time, led by the child's interest. The printed word is for you; the colored first "
+     "letter is right there for the child to notice whenever she's curious about it."),
     ("First sounds", "from ~2",
      "Sound games with the picture cards: “b-b-b… bal!” The colored first letter shows what "
      "to stress. Sort cards by first sound — all cards for a letter share their band color."),
-    ("Letters", "child-led, often 2–5",
-     "Bring in the letter-family cards; match picture cards to their letter. Plenty of "
-     "children are fascinated by letters as toddlers — if she's already pointing at them, "
-     "follow her lead. The specimen row is the same letter in different clothes."),
+    ("Letters", "child-led, alongside words",
+     "Bring in the letter-family cards and match picture cards to their letter. Many "
+     "children are keen on letters as young toddlers — if she's already pointing at them, "
+     "follow her lead rather than holding the cards back for a later age."),
+    ("First words", "once a few sounds are known",
+     "When the child knows a handful of letter sounds, start blending them: say the sounds "
+     "close together and let them melt into the word — “mmm-aaa-nnn… man”. Slide a finger "
+     "under the letters as you go. Short, sound-it-out words first, with the picture there "
+     "to confirm the answer. This is the bridge from single letters to reading."),
+]
+
+# (heading, body) — two things worth knowing about how letters behave, so they
+# don't ambush you mid-game.
+NOTES_TITLE = "Two things about letters"
+NOTES = [
+    ("A letter wears different clothes",
+     "The same letter looks different as a capital and a small letter, in print and in "
+     "handwriting — A and a are one letter. Children learn this by seeing it, not by being "
+     "told: point out the same letter in its many forms, on the card, on a sign, in a name. "
+     "The specimen row on each letter-family card is built for exactly this — one letter, "
+     "different clothes."),
+    ("A letter can make more than one sound",
+     "Some letters aren't loyal to one sound. Vowels come short and long (the a in “appel” "
+     "versus “maan”); a c can sound like a k or an s. Teach the sound in the card's word "
+     "first — one letter, one sound — and mention the others only later, as “this one can "
+     "also say…”. Don't crowd the first sound with its exceptions."),
 ]
 
 OUTRO = ("Say letter sounds, not names — “mmm”, not “em”. The word list "

--- a/lettercards/howto.py
+++ b/lettercards/howto.py
@@ -1,0 +1,32 @@
+"""Shared 'Using the cards' guidance.
+
+Single source of truth: the final PDF how-to page is drawn from these
+strings, and a test asserts the README's "Using the cards" section mirrors
+them verbatim — so the printed guidance and the README can't drift.
+"""
+
+TITLE = "Using the cards"
+
+INTRO = ("Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive "
+         "toddlers. The deck grows with the child; don't use all of it at once. The ages "
+         "below are the roughest of guides: children vary enormously and many are keen on "
+         "letters long before they're \"supposed\" to be — follow the child, not the number.")
+
+# (stage, indicative ages, what to do)
+STAGES = [
+    ("Naming", "from ~1",
+     "As soon as the child points at and names pictures — often early in the second year — "
+     "start here. Picture cards only; letter cards stay in the drawer. Show a card, say the "
+     "word, let the child point and name. A handful of cards at a time, led by the child's "
+     "interest. The printed word is for you, not them."),
+    ("First sounds", "from ~2",
+     "Sound games with the picture cards: “b-b-b… bal!” The colored first letter shows what "
+     "to stress. Sort cards by first sound — all cards for a letter share their band color."),
+    ("Letters", "child-led, often 2–5",
+     "Bring in the letter-family cards; match picture cards to their letter. Plenty of "
+     "children are fascinated by letters as toddlers — if she's already pointing at them, "
+     "follow her lead. The specimen row is the same letter in different clothes."),
+]
+
+OUTRO = ("Say letter sounds, not names — “mmm”, not “em”. The word list "
+         "is curated for this: the first letter is the first sound.")

--- a/lettercards/howto.py
+++ b/lettercards/howto.py
@@ -10,9 +10,10 @@ letter-learning progression is frozen for v3 — see issue #26.
 
 TITLE = "Using the cards"
 
-INTRO = ("Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive "
-         "toddlers. The deck grows with the child; don't use all of it at once — show a "
-         "handful of cards at a time, led by the child's interest.")
+INTRO = ("The deck grows with the child — don't use all of it at once. Show a card, say the "
+         "word, and let the child point and name it; a handful of cards at a time, led by "
+         "the child's interest. Keep it playful, and stop before it becomes a drill.")
 
-OUTRO = ("Say letter sounds, not names — “mmm”, not “em”. The word list "
-         "is curated for this: the first letter is the first sound.")
+OUTRO = ("Say letter sounds, not names — “mmm”, not “em”. The colored first letter is that "
+         "sound — the first sound of the word — and every card for a letter shares its band "
+         "color, so the cards sort into families.")

--- a/lettercards/howto.py
+++ b/lettercards/howto.py
@@ -3,56 +3,16 @@
 Single source of truth: the PDF how-to page is drawn from these strings, and a
 test asserts the README's "Using the cards" section mirrors them verbatim — so
 the printed guidance and the README can't drift.
+
+Deliberately minimal (v2): a practical page, not a pedagogy. The staged
+letter-learning progression is frozen for v3 — see issue #26.
 """
 
 TITLE = "Using the cards"
 
 INTRO = ("Print on thick paper (≥ 200 g/m²) or laminate — plain paper doesn't survive "
-         "toddlers. The deck grows with the child; don't use all of it at once. Words and "
-         "letters can grow together from the very start: a child who loves a picture card "
-         "can just as happily notice the colored letter on it, often well into the second "
-         "year. You don't have to wait for a \"right age\" — recognising letters isn't "
-         "gated behind one; it's blending them into words that usually comes later. So the "
-         "ages below are the roughest of guides. Follow the child, not the number.")
-
-# (stage, indicative ages, what to do). The stages overlap and are led by the
-# child's interest — they are not gates to clear in order.
-STAGES = [
-    ("Naming", "from ~1",
-     "As soon as the child points at and names pictures — often early in the second year — "
-     "start here. Show a card, say the word, let the child point and name. A handful at a "
-     "time, led by the child's interest. The printed word is for you; the colored first "
-     "letter is right there for the child to notice whenever she's curious about it."),
-    ("First sounds", "from ~2",
-     "Sound games with the picture cards: “b-b-b… bal!” The colored first letter shows what "
-     "to stress. Sort cards by first sound — all cards for a letter share their band color."),
-    ("Letters", "child-led, alongside words",
-     "Bring in the letter-family cards and match picture cards to their letter. Many "
-     "children are keen on letters as young toddlers — if she's already pointing at them, "
-     "follow her lead rather than holding the cards back for a later age."),
-    ("First words", "once a few sounds are known",
-     "When the child knows a handful of letter sounds, start blending them: say the sounds "
-     "close together and let them melt into the word — “mmm-aaa-nnn… man”. Slide a finger "
-     "under the letters as you go. Short, sound-it-out words first, with the picture there "
-     "to confirm the answer. This is the bridge from single letters to reading."),
-]
-
-# (heading, body) — two things worth knowing about how letters behave, so they
-# don't ambush you mid-game.
-NOTES_TITLE = "Two things about letters"
-NOTES = [
-    ("A letter wears different clothes",
-     "The same letter looks different as a capital and a small letter, in print and in "
-     "handwriting — A and a are one letter. Children learn this by seeing it, not by being "
-     "told: point out the same letter in its many forms, on the card, on a sign, in a name. "
-     "The specimen row on each letter-family card is built for exactly this — one letter, "
-     "different clothes."),
-    ("A letter can make more than one sound",
-     "Some letters aren't loyal to one sound. Vowels come short and long (the a in “appel” "
-     "versus “maan”); a c can sound like a k or an s. Teach the sound in the card's word "
-     "first — one letter, one sound — and mention the others only later, as “this one can "
-     "also say…”. Don't crowd the first sound with its exceptions."),
-]
+         "toddlers. The deck grows with the child; don't use all of it at once — show a "
+         "handful of cards at a time, led by the child's interest.")
 
 OUTRO = ("Say letter sounds, not names — “mmm”, not “em”. The word list "
          "is curated for this: the first letter is the first sound.")

--- a/lettercards/layout.py
+++ b/lettercards/layout.py
@@ -108,6 +108,53 @@ def _tint(color, alpha):
     return Color(color.red, color.green, color.blue, alpha=alpha)
 
 
+def _wrap(text, font, size, max_w):
+    """Greedy word-wrap to lines no wider than max_w."""
+    lines, cur = [], ""
+    for word in text.split():
+        trial = f"{cur} {word}".strip()
+        if pdfmetrics.stringWidth(trial, font, size) <= max_w or not cur:
+            cur = trial
+        else:
+            lines.append(cur)
+            cur = word
+    if cur:
+        lines.append(cur)
+    return lines
+
+
+def draw_howto_page(c):
+    """A one-page parent guide, drawn from lettercards.howto (shared source)."""
+    from . import howto
+    register_fonts()
+    mx = 20 * mm
+    max_w = PAGE_W - 2 * mx
+    y = PAGE_H - 26 * mm
+
+    def paragraph(text, font, size, color, indent=0):
+        nonlocal y
+        c.setFont(font, size)
+        c.setFillColor(color)
+        for line in _wrap(text, font, size, max_w - indent):
+            c.drawString(mx + indent, y, line)
+            y -= size * 1.45
+
+    c.setFillColor(WORD_COLOR)
+    c.setFont(PRIMARY, 26)
+    c.drawString(mx, y, howto.TITLE)
+    y -= 13 * mm
+    paragraph(howto.INTRO, PILL_FONT, 12, WORD_COLOR)
+    y -= 5 * mm
+    for name, ages, body in howto.STAGES:
+        c.setFont(PRIMARY, 14)
+        c.setFillColor(HIGHLIGHT)
+        c.drawString(mx, y, f"{name}   {ages}")
+        y -= 8 * mm
+        paragraph(body, PILL_FONT, 12, WORD_COLOR, indent=6 * mm)
+        y -= 6 * mm
+    paragraph(howto.OUTRO, PILL_FONT, 12, WORD_COLOR)
+
+
 def _card_base(c, x, y, fill):
     c.setStrokeColor(BORDER)
     c.setLineWidth(0.5)

--- a/lettercards/layout.py
+++ b/lettercards/layout.py
@@ -131,18 +131,37 @@ def _wrap(text, font, size, max_w):
 
 
 def draw_howto_page(c):
-    """A one-page parent guide, drawn from lettercards.howto (shared source)."""
+    """The parent guide, drawn from lettercards.howto (shared source). Flows
+    onto a second page when the content needs it; returns the page count."""
     from . import howto
     register_fonts()
     mx = 20 * mm
     max_w = PAGE_W - 2 * mx
-    y = PAGE_H - 26 * mm
+    top, bottom = PAGE_H - 26 * mm, 22 * mm
+    y = top
+    pages = 1
+
+    def space_for(h):
+        nonlocal y, pages
+        if y - h < bottom:
+            c.showPage()
+            y = top
+            pages += 1
+
+    def heading(text, size):
+        nonlocal y
+        space_for(size * 1.2)
+        c.setFont(PRIMARY, size)
+        c.setFillColor(HIGHLIGHT)
+        c.drawString(mx, y, text)
+        y -= size * 1.45 + 3 * mm
 
     def paragraph(text, font, size, color, indent=0):
         nonlocal y
-        c.setFont(font, size)
-        c.setFillColor(color)
         for line in _wrap(text, font, size, max_w - indent):
+            space_for(size)
+            c.setFont(font, size)
+            c.setFillColor(color)
             c.drawString(mx + indent, y, line)
             y -= size * 1.45
 
@@ -153,13 +172,16 @@ def draw_howto_page(c):
     paragraph(howto.INTRO, PILL_FONT, 12, WORD_COLOR)
     y -= 5 * mm
     for name, ages, body in howto.STAGES:
-        c.setFont(PRIMARY, 14)
-        c.setFillColor(HIGHLIGHT)
-        c.drawString(mx, y, f"{name}   {ages}")
-        y -= 8 * mm
+        heading(f"{name}   {ages}", 14)
+        paragraph(body, PILL_FONT, 12, WORD_COLOR, indent=6 * mm)
+        y -= 6 * mm
+    heading(howto.NOTES_TITLE, 16)
+    for name, body in howto.NOTES:
+        heading(name, 13)
         paragraph(body, PILL_FONT, 12, WORD_COLOR, indent=6 * mm)
         y -= 6 * mm
     paragraph(howto.OUTRO, PILL_FONT, 12, WORD_COLOR)
+    return pages
 
 
 def _card_base(c, x, y, fill, radius=CORNER_R):

--- a/lettercards/layout.py
+++ b/lettercards/layout.py
@@ -131,57 +131,29 @@ def _wrap(text, font, size, max_w):
 
 
 def draw_howto_page(c):
-    """The parent guide, drawn from lettercards.howto (shared source). Flows
-    onto a second page when the content needs it; returns the page count."""
+    """A single-page parent guide, drawn from lettercards.howto (shared source).
+    Deliberately minimal — the staged pedagogy is frozen for v3 (see #26)."""
     from . import howto
     register_fonts()
     mx = 20 * mm
     max_w = PAGE_W - 2 * mx
-    top, bottom = PAGE_H - 26 * mm, 22 * mm
-    y = top
-    pages = 1
+    y = PAGE_H - 26 * mm
 
-    def space_for(h):
-        nonlocal y, pages
-        if y - h < bottom:
-            c.showPage()
-            y = top
-            pages += 1
-
-    def heading(text, size):
+    def paragraph(text):
         nonlocal y
-        space_for(size * 1.2)
-        c.setFont(PRIMARY, size)
-        c.setFillColor(HIGHLIGHT)
-        c.drawString(mx, y, text)
-        y -= size * 1.45 + 3 * mm
-
-    def paragraph(text, font, size, color, indent=0):
-        nonlocal y
-        for line in _wrap(text, font, size, max_w - indent):
-            space_for(size)
-            c.setFont(font, size)
-            c.setFillColor(color)
-            c.drawString(mx + indent, y, line)
-            y -= size * 1.45
+        c.setFont(PILL_FONT, 12)
+        c.setFillColor(WORD_COLOR)
+        for line in _wrap(text, PILL_FONT, 12, max_w):
+            c.drawString(mx, y, line)
+            y -= 12 * 1.45
 
     c.setFillColor(WORD_COLOR)
     c.setFont(PRIMARY, 26)
     c.drawString(mx, y, howto.TITLE)
     y -= 13 * mm
-    paragraph(howto.INTRO, PILL_FONT, 12, WORD_COLOR)
-    y -= 5 * mm
-    for name, ages, body in howto.STAGES:
-        heading(f"{name}   {ages}", 14)
-        paragraph(body, PILL_FONT, 12, WORD_COLOR, indent=6 * mm)
-        y -= 6 * mm
-    heading(howto.NOTES_TITLE, 16)
-    for name, body in howto.NOTES:
-        heading(name, 13)
-        paragraph(body, PILL_FONT, 12, WORD_COLOR, indent=6 * mm)
-        y -= 6 * mm
-    paragraph(howto.OUTRO, PILL_FONT, 12, WORD_COLOR)
-    return pages
+    paragraph(howto.INTRO)
+    y -= 6 * mm
+    paragraph(howto.OUTRO)
 
 
 def _card_base(c, x, y, fill, radius=CORNER_R):

--- a/lettercards/render.py
+++ b/lettercards/render.py
@@ -52,7 +52,8 @@ def render_pdf(cards: list[Card], deck_dir: Path, output: Path,
     pages = (len(items) + per_page - 1) // per_page
     if howto:
         c.showPage()
-        pages += layout.draw_howto_page(c)
+        layout.draw_howto_page(c)
+        pages += 1
 
     c.save()
     return {

--- a/lettercards/render.py
+++ b/lettercards/render.py
@@ -52,8 +52,7 @@ def render_pdf(cards: list[Card], deck_dir: Path, output: Path,
     pages = (len(items) + per_page - 1) // per_page
     if howto:
         c.showPage()
-        layout.draw_howto_page(c)
-        pages += 1
+        pages += layout.draw_howto_page(c)
 
     c.save()
     return {

--- a/lettercards/render.py
+++ b/lettercards/render.py
@@ -9,11 +9,13 @@ from . import layout
 from .deck import Card, resolve_image
 
 
-def render_pdf(cards: list[Card], deck_dir: Path, output: Path) -> dict:
+def render_pdf(cards: list[Card], deck_dir: Path, output: Path,
+               howto: bool = False) -> dict:
     """Render picture + letter cards to an A4 PDF. Returns stats.
 
     Each word gets a picture card; each distinct letter additionally
-    gets one letter-family card.
+    gets one letter-family card. ``howto=True`` appends a final parent
+    how-to page so the guidance travels with the printout.
     """
     c = canvas.Canvas(str(output), pagesize=A4)
     c.setTitle("Letterkaarten")
@@ -40,10 +42,16 @@ def render_pdf(cards: list[Card], deck_dir: Path, output: Path) -> dict:
         else:
             layout.draw_letter_card(c, x, y, card.letter)
 
+    pages = (len(items) + per_page - 1) // per_page
+    if howto:
+        c.showPage()
+        layout.draw_howto_page(c)
+        pages += 1
+
     c.save()
     return {
         "cards": len(items),
         "picture_cards": len(items) - len(seen_letters),
         "letter_cards": len(seen_letters),
-        "pages": (len(items) + per_page - 1) // per_page,
+        "pages": pages,
     }

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -191,31 +191,15 @@ def test_howto_page_and_readme_share_one_source(tmp_path):
     from lettercards import howto
     readme = re.sub(r"\s+", " ", (Path(__file__).parent.parent / "README.md")
                     .read_text(encoding="utf-8"))
-    bodies = ([howto.INTRO, howto.OUTRO, howto.NOTES_TITLE]
-              + [b for _, _, b in howto.STAGES] + [b for _, b in howto.NOTES])
-    for text in bodies:
+    for text in (howto.INTRO, howto.OUTRO):
         assert re.sub(r"\s+", " ", text) in readme  # README can't drift from howto.py
-    for name, ages, _ in howto.STAGES:
-        assert name in readme and ages in readme
-    for name, _ in howto.NOTES:
-        assert name in readme
 
     fitz = pytest.importorskip("fitz")
     full, filtered = tmp_path / "full.pdf", tmp_path / "one.pdf"
     assert main(["render", "starter", "-o", str(full)]) == 0
     assert main(["render", "starter", "--cards", "zebra", "-o", str(filtered)]) == 0
-    full_doc = fitz.open(full)
-    full_text = "".join(p.get_text() for p in full_doc)     # guide may span 2 pages
-    assert howto.TITLE in full_text and howto.NOTES_TITLE in full_text
+    assert howto.TITLE in fitz.open(full)[-1].get_text()          # last page is the guide
     assert howto.TITLE not in fitz.open(filtered)[-1].get_text()  # reprint skips it
-
-    # the reported page count includes however many pages the guide flows onto
-    from lettercards.deck import printable_cards, resolve_deck_dir
-    from lettercards.render import render_pdf
-    deck_dir = resolve_deck_dir("starter")
-    stats = render_pdf(printable_cards(load_deck(deck_dir), deck_dir),
-                       deck_dir, tmp_path / "stats.pdf", howto=True)
-    assert stats["pages"] == fitz.open(tmp_path / "stats.pdf").page_count
 
 
 def test_cli_photo_crops_square(tmp_path):

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -191,17 +191,31 @@ def test_howto_page_and_readme_share_one_source(tmp_path):
     from lettercards import howto
     readme = re.sub(r"\s+", " ", (Path(__file__).parent.parent / "README.md")
                     .read_text(encoding="utf-8"))
-    for text in [howto.INTRO, howto.OUTRO] + [body for _, _, body in howto.STAGES]:
+    bodies = ([howto.INTRO, howto.OUTRO, howto.NOTES_TITLE]
+              + [b for _, _, b in howto.STAGES] + [b for _, b in howto.NOTES])
+    for text in bodies:
         assert re.sub(r"\s+", " ", text) in readme  # README can't drift from howto.py
     for name, ages, _ in howto.STAGES:
         assert name in readme and ages in readme
+    for name, _ in howto.NOTES:
+        assert name in readme
 
     fitz = pytest.importorskip("fitz")
     full, filtered = tmp_path / "full.pdf", tmp_path / "one.pdf"
     assert main(["render", "starter", "-o", str(full)]) == 0
     assert main(["render", "starter", "--cards", "zebra", "-o", str(filtered)]) == 0
-    assert howto.TITLE in fitz.open(full)[-1].get_text()          # last page is the guide
+    full_doc = fitz.open(full)
+    full_text = "".join(p.get_text() for p in full_doc)     # guide may span 2 pages
+    assert howto.TITLE in full_text and howto.NOTES_TITLE in full_text
     assert howto.TITLE not in fitz.open(filtered)[-1].get_text()  # reprint skips it
+
+    # the reported page count includes however many pages the guide flows onto
+    from lettercards.deck import printable_cards, resolve_deck_dir
+    from lettercards.render import render_pdf
+    deck_dir = resolve_deck_dir("starter")
+    stats = render_pdf(printable_cards(load_deck(deck_dir), deck_dir),
+                       deck_dir, tmp_path / "stats.pdf", howto=True)
+    assert stats["pages"] == fitz.open(tmp_path / "stats.pdf").page_count
 
 
 def test_cli_photo_crops_square(tmp_path):

--- a/tests/test_lettercards.py
+++ b/tests/test_lettercards.py
@@ -131,6 +131,27 @@ def test_cli_render_missing_deck_is_friendly(tmp_path, capsys):
     assert "error:" in capsys.readouterr().err
 
 
+def test_howto_page_and_readme_share_one_source(tmp_path):
+    """The how-to guidance is one Python source; README mirrors it and a full
+    render appends it as a page, while filtered renders skip it."""
+    import re
+    from pathlib import Path
+    from lettercards import howto
+    readme = re.sub(r"\s+", " ", (Path(__file__).parent.parent / "README.md")
+                    .read_text(encoding="utf-8"))
+    for text in [howto.INTRO, howto.OUTRO] + [body for _, _, body in howto.STAGES]:
+        assert re.sub(r"\s+", " ", text) in readme  # README can't drift from howto.py
+    for name, ages, _ in howto.STAGES:
+        assert name in readme and ages in readme
+
+    fitz = pytest.importorskip("fitz")
+    full, filtered = tmp_path / "full.pdf", tmp_path / "one.pdf"
+    assert main(["render", "starter", "-o", str(full)]) == 0
+    assert main(["render", "starter", "--cards", "zebra", "-o", str(filtered)]) == 0
+    assert howto.TITLE in fitz.open(full)[-1].get_text()          # last page is the guide
+    assert howto.TITLE not in fitz.open(filtered)[-1].get_text()  # reprint skips it
+
+
 def test_cli_photo_crops_square(tmp_path):
     from PIL import Image
     src = tmp_path / "portrait.jpg"


### PR DESCRIPTION
Closes #11. Delivers the v2 slice per the #26 roadmap decision — supersedes #23 (that branch had gone stale against `main`).

The pedagogy lived only in a `layout.py` docstring no parent would see. This puts a small, practical guide where it helps: in the README and on a page that prints with the deck. Per #26, v2 stays small — **the staged letter-learning progression (ages, voices, shapes, blending) is deliberately frozen for v3**, not shipped here.

## What's on the page vs. in the README
The printed page travels with the cards, so it's the how-to-*play* you'd want at the table — not print setup:

- **Printed page** (`howto.py` → `draw_howto_page`): deck grows with the child so don't use it all at once; show a card, say the word, let the child point and name; a handful at a time, keep it playful, stop before it's a drill. Then the tip parents most often get wrong — say **sounds**, not names — and what the card design signals: the colored first letter *is* that sound, and shared band colors sort cards into families.
- **README** additionally carries the print-prep line (thick paper ≥ 200 g/m² or laminate), which is pointless on a page you hold *after* printing.

## One shared source
`lettercards/howto.py` holds the guidance strings; `layout.draw_howto_page` renders them as a single clean page in the card fonts/colors; `test_howto_page_and_readme_share_one_source` asserts the README mirrors those strings verbatim (whitespace-normalized) — so the printed page and README can't drift, with no build step.

## Behaviour
- A full `lettercards render` appends the how-to as the **final page** (starter deck: 7 pages, guide last).
- Filtered reprints (`--letters`/`--cards`) **skip** it, so a single-letter reprint stays clean.
- **`--no-howto`** omits it from a full render too.

## Verification
- All 18 tests pass; Python budget **885 / 1000**.
- Rendered the starter deck and eyeballed the final page — one clean, in-hand guide, no print-setup text on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAiGXFTz347XXLTFbTtyHe)_